### PR TITLE
Adding publish command.

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -49,3 +49,8 @@ poetry *FLAGS:
 shell:
     poetry shell
 
+build:
+    poetry build
+
+publish: build
+    poetry publish -u __token__ -p $(gcloud secrets versions access --secret=fixie-sdk-pypi-api-token latest)


### PR DESCRIPTION
Allows us to run `just publish` to publish the SDK to PyPI.