### PR TITLE
add simple langchain replit agent with zero shots

### DIFF
--- a/examples/agents/langchain_agent_zero_shot.py
+++ b/examples/agents/langchain_agent_zero_shot.py
@@ -1,0 +1,59 @@
+# example of code for deploying a langchain agent with replit 
+# https://replit.com/@llamalabs/langchain-agent this will be template public link on replit once ready for launch 
+# https://langchain-agent.llamalabs.repl.co/ this is the public link to the agent once deployed
+
+
+import re
+import json
+import os
+
+
+from langchain.prompts import PromptTemplate
+from langchain.chains import LLMChain
+from langchain.llms import OpenAI
+from flask import Flask, request, Response
+
+
+app = Flask(__name__)
+
+QUERIES = {
+  "queries": ["What is a good name for a company that builds cookies?",
+  "What is a good name for a company that builds books?"]
+}
+
+# set OpenAI API key in secrets tab on replit 
+# OPENAI_API_KEY = 'your_key'
+my_secret = os.environ['OPENAI_API_KEY']
+
+llm = OpenAI(temperature=0.9)
+
+# construct an LLMChain which takes user input, formats it with a PromptTemplate,
+# and then passes the formatted response to an LLM
+prompt = PromptTemplate(
+    input_variables=["product"],
+    template="What is a good name for a company that builds {product}?",
+)
+chain = LLMChain(llm=llm, prompt=prompt)
+
+
+def get_chain_response(product: str):
+  response = chain.run(product)
+  print(f"AI-generated name: {response.strip()}")
+  return response
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+  if request.method == "GET":
+    return Response(json.dumps(QUERIES), mimetype='application/json')
+  elif request.method == "POST":
+    obj = request.json
+    #this extracts a product from the message text if it is written between square brackets 
+    #example: "What should I call a company that makes[product]"
+    product = re.search(r'\[(.*?)\]', obj["message"]["text"])[0]  
+  response = get_chain_response(product)
+  return {"message": {"text": f"{response.strip()}"}}
+
+
+
+app.run(host='0.0.0.0', port=81)


### PR DESCRIPTION
This PR demonstrates the simple implementation of an agent that generates company names using langchain for calling LLMs and replit for deploying the back-end. 

Once the back-end script is running on replit as seen below 
<img width="1400" alt="Screenshot 2023-01-31 at 11 59 44 AM" src="https://user-images.githubusercontent.com/1336419/215869555-77529837-3eb9-4235-b10e-11eb6d960034.png">


You can go and add it in Llama Labs app here [https://app.fixie.ai/agents/](https://app.fixie.ai/agents/)
<img width="833" alt="Screenshot 2023-01-31 at 11 58 35 AM" src="https://user-images.githubusercontent.com/1336419/215869766-de8284f0-1738-4d82-afc8-1fad98b8b3bd.png">


And test it by using the following query in the chat: "@langchain-company Generate a company name for someone who makes [nails]" (the product name for the company should always be indicated using square brackets for this zero shot agent) 
Example response: 

<img width="831" alt="Screenshot 2023-01-31 at 12 03 58 PM" src="https://user-images.githubusercontent.com/1336419/215870210-2badacfe-f641-4195-abea-3237c459b5c7.png">



