### PR TITLE
Remove duplicated mypy config

### DIFF
--- a/fixieai/agents/code_shot.py
+++ b/fixieai/agents/code_shot.py
@@ -169,7 +169,7 @@ class CodeShotAgent:
 
     def _handshake(self) -> fastapi.Response:
         """Returns the agent's metadata in YAML format."""
-        metadata = AgentMetadata(self.base_prompt, self.few_shots)  # type: ignore[call-arg]
+        metadata = AgentMetadata(self.base_prompt, self.few_shots)
         yaml_content = yaml.dump(dataclasses.asdict(metadata))
         return fastapi.Response(yaml_content, media_type="application/yaml")
 
@@ -256,9 +256,9 @@ def _wrap_with_agent_response(
     value: Union[str, api.Message, api.AgentResponse]
 ) -> api.AgentResponse:
     if isinstance(value, str):
-        return api.AgentResponse(api.Message(value))  # type: ignore[call-arg]
+        return api.AgentResponse(api.Message(value))
     elif isinstance(value, api.Message):
-        return api.AgentResponse(value)  # type: ignore[call-arg]
+        return api.AgentResponse(value)
     elif isinstance(value, api.AgentResponse):
         return value
     else:

--- a/fixieai/agents/code_shot_test.py
+++ b/fixieai/agents/code_shot_test.py
@@ -163,11 +163,11 @@ def bad_duck_typed_func3(query, *user_storage):
 
 
 def good_typed_func1(query: fixieai.Message) -> fixieai.AgentResponse:
-    return fixieai.AgentResponse(fixieai.Message("test"))  # type: ignore[call-arg]
+    return fixieai.AgentResponse(fixieai.Message("test"))
 
 
 def good_typed_func2(query: fixieai.Message) -> fixieai.Message:
-    return fixieai.Message("test")  # type: ignore[call-arg]
+    return fixieai.Message("test")
 
 
 def good_typed_func3(user_storage: fixieai.UserStorage) -> str:
@@ -177,7 +177,7 @@ def good_typed_func3(user_storage: fixieai.UserStorage) -> str:
 def good_typed_func4(
     user_storage: fixieai.UserStorage, oauth_handler: fixieai.OAuthHandler
 ) -> fixieai.Message:
-    return fixieai.Message("test")  # type: ignore[call-arg]
+    return fixieai.Message("test")
 
 
 def good_semi_typed_func1(query: fixieai.Message):

--- a/fixieai/client/agent.py
+++ b/fixieai/client/agent.py
@@ -44,49 +44,49 @@ class Agent:
         """Return the agentId for this Agent."""
         if self._metadata is None:
             return None
-        return self._metadata["agentId"]
+        return self._metadata["agentId"]  # type: ignore[no-any-return]
 
     @property
     def name(self) -> Optional[str]:
         """Return the name for this Agent."""
         if self._metadata is None:
             return None
-        return self._metadata["name"]
+        return self._metadata["name"]  # type: ignore[no-any-return]
 
     @property
     def description(self) -> Optional[str]:
         """Return the description for this Agent."""
         if self._metadata is None:
             return None
-        return self._metadata["description"]
+        return self._metadata["description"]  # type: ignore[no-any-return]
 
     @property
     def queries(self) -> Optional[List[str]]:
         """Return the queries for this Agent."""
         if self._metadata is None:
             return None
-        return self._metadata["queries"]
+        return self._metadata["queries"]  # type: ignore[no-any-return]
 
     @property
     def more_info_url(self) -> Optional[str]:
         """Return the more info URL for this Agent."""
         if self._metadata is None:
             return None
-        return self._metadata["moreInfoUrl"]
+        return self._metadata["moreInfoUrl"]  # type: ignore[no-any-return]
 
     @property
     def published(self) -> Optional[bool]:
         """Return the published status for this Agent."""
         if self._metadata is None:
             return None
-        return self._metadata["published"]
+        return self._metadata["published"]  # type: ignore[no-any-return]
 
     @property
     def owner(self) -> Optional[str]:
         """Return the owner of this Agent."""
         if self._metadata is None:
             return None
-        return self._metadata["owner"]["username"]
+        return self._metadata["owner"]["username"]  # type: ignore[no-any-return]
 
     def get_metadata(self) -> Dict[str, Any]:
         """Return metadata about this Agent."""
@@ -114,7 +114,7 @@ class Agent:
         )
         if "agentByHandle" not in result or result["agentByHandle"] is None:
             raise ValueError(f"Cannot fetch agent metadata for {self._handle}")
-        return result["agentByHandle"]
+        return result["agentByHandle"]  # type: ignore[no-any-return]
 
     def create_agent(
         self,

--- a/fixieai/client/agent.py
+++ b/fixieai/client/agent.py
@@ -44,49 +44,63 @@ class Agent:
         """Return the agentId for this Agent."""
         if self._metadata is None:
             return None
-        return self._metadata["agentId"]  # type: ignore[no-any-return]
+        agent_id = self._metadata["agentId"]
+        assert isinstance(agent_id, str)
+        return agent_id
 
     @property
     def name(self) -> Optional[str]:
         """Return the name for this Agent."""
         if self._metadata is None:
             return None
-        return self._metadata["name"]  # type: ignore[no-any-return]
+        name = self._metadata["name"]
+        assert isinstance(name, str)
+        return name
 
     @property
     def description(self) -> Optional[str]:
         """Return the description for this Agent."""
         if self._metadata is None:
             return None
-        return self._metadata["description"]  # type: ignore[no-any-return]
+        description = self._metadata["description"]
+        assert isinstance(description, str)
+        return description
 
     @property
     def queries(self) -> Optional[List[str]]:
         """Return the queries for this Agent."""
         if self._metadata is None:
             return None
-        return self._metadata["queries"]  # type: ignore[no-any-return]
+        queries = self._metadata["queries"]
+        assert isinstance(queries, list) and all(isinstance(q, str) for q in queries)
+        return queries
 
     @property
     def more_info_url(self) -> Optional[str]:
         """Return the more info URL for this Agent."""
         if self._metadata is None:
             return None
-        return self._metadata["moreInfoUrl"]  # type: ignore[no-any-return]
+        more_info_url = self._metadata["moreInfoUrl"]
+        assert isinstance(more_info_url, str)
+        return more_info_url
 
     @property
     def published(self) -> Optional[bool]:
         """Return the published status for this Agent."""
         if self._metadata is None:
             return None
-        return self._metadata["published"]  # type: ignore[no-any-return]
+        published = self._metadata["published"]
+        assert isinstance(published, bool)
+        return published
 
     @property
     def owner(self) -> Optional[str]:
         """Return the owner of this Agent."""
         if self._metadata is None:
             return None
-        return self._metadata["owner"]["username"]  # type: ignore[no-any-return]
+        owner_username = self._metadata["owner"]["username"]
+        assert isinstance(owner_username, str)
+        return owner_username
 
     def get_metadata(self) -> Dict[str, Any]:
         """Return metadata about this Agent."""

--- a/fixieai/client/agent.py
+++ b/fixieai/client/agent.py
@@ -128,7 +128,11 @@ class Agent:
         )
         if "agentByHandle" not in result or result["agentByHandle"] is None:
             raise ValueError(f"Cannot fetch agent metadata for {self._handle}")
-        return result["agentByHandle"]  # type: ignore[no-any-return]
+        agent_by_handle = result["agentByHandle"]
+        assert isinstance(agent_by_handle, dict) and all(
+            isinstance(k, str) for k in agent_by_handle.keys()
+        )
+        return agent_by_handle
 
     def create_agent(
         self,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,0 @@
-[mypy]
-ignore_missing_imports = True
-exclude = (^fixie-examples/$|^third_party/$)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ python_version = "3.8"
 warn_return_any = true
 warn_unused_configs = true
 plugins = [ "pydantic.mypy" ]
+exclude = [ "fixie-examples" ]
 
 [[tool.mypy.overrides]]
 module = "validators"


### PR DESCRIPTION
#42 added a second mypy config which overrode the existing one in `pyproject.toml` -- this removes it and adds the `fixie-examples` exclusion as well as some `ignore[no-any-return]`s for the code that requires it.