### PR TITLE
Remove agent_id from `CodeShotAgent` constructor

### DIFF
--- a/examples/agents/randint.py
+++ b/examples/agents/randint.py
@@ -6,7 +6,6 @@ import random
 
 import fixieai
 
-agent_id = "randint"
 BASE_PROMPT = (
     "I am a simple agent that generates a random number between two given values."
 )
@@ -22,7 +21,7 @@ Func[genrand] says: 8
 A: The random number is 8.
 """
 
-agent = fixieai.CodeShotAgent(agent_id, BASE_PROMPT, FEW_SHOTS)
+agent = fixieai.CodeShotAgent(BASE_PROMPT, FEW_SHOTS)
 
 
 @agent.register_func

--- a/examples/agents/randint.py
+++ b/examples/agents/randint.py
@@ -30,4 +30,5 @@ def genrand(query: fixieai.Message) -> str:
     return str(random.randint(int(low), int(high)))
 
 
-agent.serve()
+if __name__ == "__main__":
+    agent.serve()

--- a/fixieai/agents/code_shot_test.py
+++ b/fixieai/agents/code_shot_test.py
@@ -25,12 +25,12 @@ A: Simple final response
 
 
 @pytest.fixture(autouse=True)
-def mock_token_verifier():
-    with mock.patch.object(code_shot._VerifiedTokenClaims, "from_token") as from_token:
-        from_token.return_value = code_shot._VerifiedTokenClaims(
-            agent_id="fake agent id"
-        )
-        yield from_token
+def mock_token_verifier(mocker):
+    return mocker.patch.object(
+        code_shot._VerifiedTokenClaims,
+        "from_token",
+        return_value=code_shot._VerifiedTokenClaims(agent_id="fake agent id"),
+    )
 
 
 @pytest.fixture

--- a/fixieai/agents/code_shot_test.py
+++ b/fixieai/agents/code_shot_test.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import fastapi
 import pytest
 import yaml

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -94,3 +94,22 @@ def list_agents(ctx, verbose):
                 click.secho(f"    More info", fg="yellow", nl=False)
                 click.echo(f": {agent['moreInfoUrl']}")
             click.echo()
+
+
+def _default_refresh_handle():
+    """Returns the default agent handle, if there is one."""
+    try:
+        return agent_config.load_config().handle
+    except FileNotFoundError:
+        return None
+
+
+@agent.command("refresh", help="Indicate that the agent's prompts should be refreshed.")
+@click.argument(
+    "handle",
+    required=True,
+    default=_default_refresh_handle,
+)
+@click.pass_context
+def refresh(ctx, handle):
+    ctx.obj.client.refresh_agent(handle)

--- a/fixieai/client/client.py
+++ b/fixieai/client/client.py
@@ -57,9 +57,6 @@ class FixieClient:
     """FixieClient is a client to the Fixie system.
 
     Args:
-        api_url: The URL of the Fixie API server. If not provided, the
-            FIXIE_API_URL environment variable will be used. If that is not
-            set, the default value of "https://app.fixie.ai " will be used.
         api_key: The API key for the Fixie API server. If not provided, the
             FIXIE_API_KEY environment variable will be used. If that is not
             set, the authenticated user API key will be used, or a ValueError
@@ -68,15 +65,13 @@ class FixieClient:
 
     def __init__(
         self,
-        api_url: Optional[str] = None,
         api_key: Optional[str] = None,
     ):
-        self._api_url = api_url or constants.FIXIE_API_URL
         self._api_key = api_key or constants.fixie_api_key()
-        logging.info(f"Using Fixie API URL: {self._api_url}")
+        logging.info(f"Using Fixie API URL: {constants.FIXIE_API_URL}")
         self._request_headers = {"Authorization": f"Bearer {self._api_key}"}
         transport = RequestsHTTPTransport(
-            url=f"{self._api_url}/graphql",
+            url=constants.FIXIE_GRAPHQL_URL,
             headers=self._request_headers,
         )
         self._gqlclient = Client(transport=transport, fetch_schema_from_transport=False)
@@ -89,12 +84,11 @@ class FixieClient:
     @property
     def url(self) -> str:
         """Return the URL of the Fixie API server."""
-        assert self._api_url is not None
-        return self._api_url
+        return constants.FIXIE_API_URL
 
     def clone(self) -> "FixieClient":
         """Return a new FixieClient instance with the same configuration."""
-        return FixieClient(api_url=self._api_url, api_key=self._api_key)
+        return FixieClient(api_key=self._api_key)
 
     def get_agents(self) -> Dict[str, Dict[str, str]]:
         """Return metadata about all running Fixie Agents. The keys of the returned
@@ -190,6 +184,6 @@ class FixieClient:
         """Indicates that an agent's prompts should be refreshed."""
         username = self.get_current_username()
         requests.post(
-            f"{self._api_url}/api/refresh/{username}/{agent_handle}",
+            f"{constants.FIXIE_REFRESH_URL}/{username}/{agent_handle}",
             headers=self._request_headers,
         ).raise_for_status()

--- a/fixieai/client/client_test.py
+++ b/fixieai/client/client_test.py
@@ -1,180 +1,155 @@
 import pytest
-import requests_mock
 
+from fixieai import constants
 from fixieai.client.client import FixieClient
 
 
 @pytest.fixture
 def fixie_client():
-    with requests_mock.Mocker() as m:
-        m.post(
-            "https://test.fixie.ai/graphql",
-            json={"data": {"createSession": {"session": {"handle": "test-handle"}}}},
-        )
-        return FixieClient(api_url="https://test.fixie.ai", api_key="test-key")
+    return FixieClient(api_key="test-key")
 
 
-def test_get_agents(fixie_client):
-    with requests_mock.Mocker() as m:
-        m.post(
-            "https://test.fixie.ai/graphql",
-            json={"data": {"allAgents": [{"handle": "test", "name": "Test Agent"}]}},
-        )
-        assert fixie_client.get_agents() == {
-            "test": {"handle": "test", "name": "Test Agent"}
-        }
+def test_get_agents(fixie_client, requests_mock):
+    requests_mock.post(
+        constants.FIXIE_GRAPHQL_URL,
+        json={"data": {"allAgents": [{"handle": "test", "name": "Test Agent"}]}},
+    )
+    assert fixie_client.get_agents() == {
+        "test": {"handle": "test", "name": "Test Agent"}
+    }
 
 
-def test_get_agent(fixie_client):
-    with requests_mock.Mocker() as m:
-        m.post(
-            "https://test.fixie.ai/graphql",
-            json={
-                "data": {
-                    "agentByHandle": {
-                        "agentId": "testuser/test-agent-handle",
-                        "handle": "test-agent-handle",
-                        "name": "Test Agent",
-                        "description": "Test Agent Description",
-                        "queries": ["test-query"],
-                        "moreInfoUrl": "https://test.com",
-                        "published": True,
-                        "owner": {
-                            "username": "testuser",
-                        },
-                    }
+def test_get_agent(fixie_client, requests_mock):
+    requests_mock.post(
+        constants.FIXIE_GRAPHQL_URL,
+        json={
+            "data": {
+                "agentByHandle": {
+                    "agentId": "testuser/test-agent-handle",
+                    "handle": "test-agent-handle",
+                    "name": "Test Agent",
+                    "description": "Test Agent Description",
+                    "queries": ["test-query"],
+                    "moreInfoUrl": "https://test.com",
+                    "published": True,
+                    "owner": {
+                        "username": "testuser",
+                    },
                 }
-            },
-        )
-        client = FixieClient(
-            api_url="https://test.fixie.ai",
-            api_key="test-key",
-        )
-        agent = client.get_agent("test-agent-handle")
-        assert agent.handle == "test-agent-handle"
-        assert agent.agent_id == "testuser/test-agent-handle"
-        assert agent.name == "Test Agent"
-        assert agent.description == "Test Agent Description"
-        assert agent.queries == ["test-query"]
-        assert agent.more_info_url == "https://test.com"
-        assert agent.published is True
-        assert agent.owner == "testuser"
+            }
+        },
+    )
+    agent = fixie_client.get_agent("test-agent-handle")
+    assert agent.handle == "test-agent-handle"
+    assert agent.agent_id == "testuser/test-agent-handle"
+    assert agent.name == "Test Agent"
+    assert agent.description == "Test Agent Description"
+    assert agent.queries == ["test-query"]
+    assert agent.more_info_url == "https://test.com"
+    assert agent.published is True
+    assert agent.owner == "testuser"
 
 
-def test_create_agent(fixie_client):
-    with requests_mock.Mocker() as m:
-        client = FixieClient(
-            api_url="https://test.fixie.ai",
-            api_key="test-key",
-        )
+def test_create_agent(fixie_client, requests_mock):
+    requests_mock.post(
+        constants.FIXIE_GRAPHQL_URL,
+        json={
+            "data": {},
+            "errors": ["GraphQL error: No such agent: testuser/test-agent-handle"],
+        },
+    )
+    agent = fixie_client.get_agent("test-agent-handle")
+    assert agent.handle == "test-agent-handle"
+    assert agent.agent_id is None
 
-        m.post(
-            "https://test.fixie.ai/graphql",
-            json={
-                "data": {},
-                "errors": ["GraphQL error: No such agent: testuser/test-agent-handle"],
-            },
-        )
-        agent = client.get_agent("test-agent-handle")
-        assert agent.handle == "test-agent-handle"
-        assert agent.agent_id is None
-
-        # There are two GraphQL calls resulting from create_agent, we need
-        # to mock both of the responses.
-        m.post(
-            "https://test.fixie.ai/graphql",
-            [
-                {
-                    "json": {
-                        "data": {
-                            "createAgent": {
-                                "agent": {
-                                    "agentId": "testuser/test-agent-id",
-                                }
+    # There are two GraphQL calls resulting from create_agent, we need
+    # to mock both of the responses.
+    requests_mock.post(
+        constants.FIXIE_GRAPHQL_URL,
+        [
+            {
+                "json": {
+                    "data": {
+                        "createAgent": {
+                            "agent": {
+                                "agentId": "testuser/test-agent-id",
                             }
                         }
-                    },
+                    }
                 },
-                {
-                    "json": {
-                        "data": {
-                            "agentByHandle": {
-                                "agentId": "testuser/test-agent-handle",
-                                "handle": "test-agent-handle",
-                                "name": "Test Agent",
-                                "description": "Test Agent Description",
-                                "queries": [],
-                                "moreInfoUrl": "https://test.com",
-                                "published": True,
-                                "owner": {
-                                    "username": "testuser",
-                                },
-                            }
+            },
+            {
+                "json": {
+                    "data": {
+                        "agentByHandle": {
+                            "agentId": "testuser/test-agent-handle",
+                            "handle": "test-agent-handle",
+                            "name": "Test Agent",
+                            "description": "Test Agent Description",
+                            "queries": [],
+                            "moreInfoUrl": "https://test.com",
+                            "published": True,
+                            "owner": {
+                                "username": "testuser",
+                            },
                         }
-                    },
+                    }
                 },
-            ],
-        )
-        agent.create_agent(
-            name="Test Agent",
-            description="Test Agent Description",
-            more_info_url="https://test.com",
-            published=True,
-        )
-        assert agent.agent_id == "testuser/test-agent-handle"
-        assert agent.name == "Test Agent"
-        assert agent.description == "Test Agent Description"
-        assert agent.queries == []
-        assert agent.more_info_url == "https://test.com"
-        assert agent.published is True
-        assert agent.owner == "testuser"
-
-
-def test_sessions(fixie_client):
-    with requests_mock.Mocker() as m:
-        m.post(
-            "https://test.fixie.ai/graphql",
-            json={
-                "data": {
-                    "allSessions": [{"handle": "test-handle", "name": "Test Session"}]
-                }
             },
-        )
-        assert fixie_client.get_sessions() == ["test-handle"]
+        ],
+    )
+    agent.create_agent(
+        name="Test Agent",
+        description="Test Agent Description",
+        more_info_url="https://test.com",
+        published=True,
+    )
+    assert agent.agent_id == "testuser/test-agent-handle"
+    assert agent.name == "Test Agent"
+    assert agent.description == "Test Agent Description"
+    assert agent.queries == []
+    assert agent.more_info_url == "https://test.com"
+    assert agent.published is True
+    assert agent.owner == "testuser"
 
 
-def test_get_session():
-    with requests_mock.Mocker() as m:
-        m.post(
-            "https://test.fixie.ai/graphql",
-            json={
-                "data": {
-                    "sessionByHandle": {
-                        "handle": "test-handle",
-                    }
+def test_sessions(fixie_client, requests_mock):
+    requests_mock.post(
+        constants.FIXIE_GRAPHQL_URL,
+        json={
+            "data": {"allSessions": [{"handle": "test-handle", "name": "Test Session"}]}
+        },
+    )
+    assert fixie_client.get_sessions() == ["test-handle"]
+
+
+def test_get_session(fixie_client, requests_mock):
+    requests_mock.post(
+        constants.FIXIE_GRAPHQL_URL,
+        json={
+            "data": {
+                "sessionByHandle": {
+                    "handle": "test-handle",
                 }
-            },
-        )
-        client = FixieClient(
-            api_url="https://test.fixie.ai",
-            api_key="test-key",
-        )
-        session = client.get_session("test-handle")
+            }
+        },
+    )
+    session = fixie_client.get_session("test-handle")
 
-        m.post(
-            "https://test.fixie.ai/graphql",
-            json={
-                "data": {
-                    "sessionByHandle": {
-                        "handle": "test-handle",
-                        "messages": [
-                            {
-                                "id": 1,
-                                "text": "Test message",
-                            }
-                        ],
-                    }
+    requests_mock.post(
+        constants.FIXIE_GRAPHQL_URL,
+        json={
+            "data": {
+                "sessionByHandle": {
+                    "handle": "test-handle",
+                    "messages": [
+                        {
+                            "id": 1,
+                            "text": "Test message",
+                        }
+                    ],
                 }
-            },
-        )
-        assert session.get_messages() == [{"id": 1, "text": "Test message"}]
+            }
+        },
+    )
+    assert session.get_messages() == [{"id": 1, "text": "Test message"}]

--- a/fixieai/constants.py
+++ b/fixieai/constants.py
@@ -13,6 +13,8 @@ FIXIE_CONFIG_PATH = os.getenv(
     os.path.expanduser("~/.config/fixie/config.yaml"),
 )
 
+# Fixie's GraphQL URL.
+FIXIE_GRAPHQL_URL = f"{FIXIE_API_URL}/graphql"
 # Fixie's UserStorage service URL.
 FIXIE_USER_STORAGE_URL = f"{FIXIE_API_URL}/api/userstorage"
 # Fixie's refresh endpoint. It will be pinged when your agent comes alive.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ addopts = [
 python_version = "3.8"
 warn_return_any = true
 warn_unused_configs = true
+check_untyped_defs = true
 plugins = [ "pydantic.mypy" ]
 exclude = [ "fixie-examples" ]
 


### PR DESCRIPTION
- Remove `agent_id` from `CodeShotAgent` constructor
- Make it an optional parameter to `serve` to support unauthed scenarios
- Add `FixieClient.get_current_username()` and `FixieClient.refresh_agent(handle)`
- Add `fixie agent refresh [handle]` CLI command which invokes `refresh_agent` (`handle` is required, but can be inferred from local `agent.yaml` if present)
- Enable mypy `check_untyped_defs` and fix a test violation that was added in #46 by refactoring fixture
- Opportunistically take advantage of fixture refactor to add new test to exercise invalid token scenario

A followup change will update `fixie/fixie-examples` accordingly.