### PR TITLE
Encourage followup actions after `fixie agent deploy`

### DIFF
--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -1,5 +1,7 @@
 import io
 import os
+import random
+import shlex
 from contextlib import contextmanager
 from typing import BinaryIO, Dict
 
@@ -8,6 +10,7 @@ import rich.console as rich_console
 import validators
 
 import fixieai.client
+from fixieai import constants
 from fixieai.cli.agent import agent_config
 from fixieai.cli.agent import loader
 
@@ -174,13 +177,18 @@ def _spinner(console: rich_console.Console, text: str):
 
 @agent.command("deploy", help="Deploy the current agent.")
 @click.argument("path", callback=_validate_agent_path, required=False)
+@click.option(
+    "--metadata-only",
+    is_flag=True,
+    help="Only publish metadata and refresh, do not redeploy.",
+)
 @click.pass_context
-def deploy(ctx, path):
+def deploy(ctx, path, metadata_only):
     console = rich_console.Console()
     config = agent_config.load_config(path)
     agent_api = _ensure_agent_updated(ctx.obj.client, config)
 
-    if config.deployment_url is None:
+    if config.deployment_url is None and not metadata_only:
         # Deploy the agent to fixie with some bootstrapping code.
         file_streams: Dict[str, BinaryIO] = {}
         deploy_root = os.path.dirname(path)
@@ -222,3 +230,14 @@ def deploy(ctx, path):
     # Trigger a refresh with the updated deployment
     with _spinner(console, "Refreshing..."):
         ctx.obj.client.refresh_agent(config.handle)
+
+    agent_api.update_agent()
+    if agent_api.queries:
+        suggested_query = random.choice(agent_api.queries)
+    else:
+        suggested_query = "Hello!"
+
+    suggested_message = shlex.quote(f"@{agent_api.agent_id} {suggested_query}")
+    console.print(
+        f"Your agent was deployed to {constants.FIXIE_API_URL}/agents/{agent_api.agent_id}\nYou can also chat with your agent using the fixie CLI:\n\nfixie session new {suggested_message}"
+    )

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -239,5 +239,5 @@ def deploy(ctx, path, metadata_only):
 
     suggested_message = shlex.quote(f"@{agent_api.agent_id} {suggested_query}")
     console.print(
-        f"Your agent was deployed to {constants.FIXIE_API_URL}/agents/{agent_api.agent_id}\nYou can also chat with your agent using the fixie CLI:\n\nfixie session new {suggested_message}"
+        f"Your agent was deployed to {constants.FIXIE_API_URL}/agents/{agent_api.agent_id}\nYou can also chat with your agent using the fixie CLI:\n\nfixie console {suggested_message}"
     )

--- a/fixieai/cli/session/commands.py
+++ b/fixieai/cli/session/commands.py
@@ -18,11 +18,12 @@ def list_sessions(ctx):
 
 
 @session.command("new", help="Creates a new session and opens it.")
+@click.argument("message", required=False)
 @click.pass_context
-def new_session(ctx):
+def new_session(ctx, message):
     client = ctx.obj.client
     c = console.Console(client)
-    c.run()
+    c.run(message)
 
 
 @session.command("open", help="Opens a session.")

--- a/fixieai/cli/session/console.py
+++ b/fixieai/cli/session/console.py
@@ -1,4 +1,7 @@
+from typing import Optional
+
 import prompt_toolkit
+import prompt_toolkit.history
 import requests
 import rich.console as rich_console
 
@@ -21,15 +24,24 @@ class Console:
         self._history_file = history_file
         self._response_index = 0
 
-    def run(self) -> None:
+    def run(self, initial_message: Optional[str] = None) -> None:
         """Run the console application."""
+
+        PROMPT = "fixie 🚲❯ "
 
         textconsole.print("[blue]Welcome to Fixie!")
         textconsole.print(f"Connected to: {self._session.session_url}")
+
+        history = prompt_toolkit.history.FileHistory(self._history_file)
+        if initial_message:
+            prompt_toolkit.print_formatted_text(f"{PROMPT}{initial_message}")
+            history.append_string(initial_message)
+            self._query(initial_message)
+
         while True:
             in_text = prompt_toolkit.prompt(
-                "fixie 🚲❯ ",
-                history=prompt_toolkit.history.FileHistory(self._history_file),
+                PROMPT,
+                history=history,
                 auto_suggest=prompt_toolkit.auto_suggest.AutoSuggestFromHistory(),
             )
             self._query(in_text)


### PR DESCRIPTION
- Add a new optional argument to `fixie session new` to send an initial message
- Add `--metadata-only` flag to `fixie agent deploy` to update metadata/refresh without redeploying code
- Encourage users to chat with their agent with `fixie session new` or visit its page in the UI