### PR TITLE
Add --reload option (enabled by default) to `fixie agent serve`

### DIFF
--- a/fixieai/agents/code_shot.py
+++ b/fixieai/agents/code_shot.py
@@ -4,6 +4,7 @@ import dataclasses
 import functools
 import inspect
 import json
+import os
 import re
 import threading
 import time
@@ -119,20 +120,33 @@ class CodeShotAgent:
     ):
         """Starts serving the current agent at `{host}:{port}` via uvicorn.
 
-        If agent_id is specified, this pings Fixie upon startup to fetch the latest prompt and fewshots.
+        If agent_id is specified as an argument or via the FIXIE_REFRESH_AGENT_ID environment variable,
+        this pings Fixie upon startup to fetch the latest prompt and fewshots.
 
         Args:
             agent_id: The qualified agent id (`username/handle`)
             host: The address to start listening at.
             port: The port number to start listening at.
         """
+        uvicorn.run(self.app(agent_id), host=host, port=port)
+
+    def app(self, agent_id: Optional[str] = None) -> fastapi.FastAPI:
+        """Returns a fastapi.FastAPI application that serves the agent.
+
+        If agent_id is specified as an argument or via the FIXIE_REFRESH_AGENT_ID environment variable,
+        this pings Fixie upon startup to fetch the latest prompt and fewshots.
+
+        Args:
+            agent_id: The qualified agent id (`username/handle`)
+        """
         fast_api = fastapi.FastAPI()
         fast_api.include_router(self.api_router())
+        agent_id = agent_id or os.getenv("FIXIE_REFRESH_AGENT_ID")
         if agent_id:
             fast_api.add_event_handler(
                 "startup", functools.partial(_ping_fixie_async, agent_id)
             )
-        uvicorn.run(fast_api, host=host, port=port)
+        return fast_api
 
     def api_router(self) -> fastapi.APIRouter:
         """Returns a fastapi.APIRouter object that serves the agent."""

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -224,10 +224,13 @@ def _ensure_agent_updated(
     "--tunnel/--no-tunnel",
     is_flag=True,
     default=True,
-    help="Create a tunnel using localhost.run.",
+    help="(default enabled) Create a tunnel using localhost.run.",
 )
 @click.option(
-    "--reload/--no-reload", is_flag=True, default=True, help="Enable auto-reload."
+    "--reload/--no-reload",
+    is_flag=True,
+    default=True,
+    help="(default enabled) Reload automatically.",
 )
 @click.pass_context
 def serve(ctx, path, host, port, tunnel, reload):

--- a/fixieai/cli/session/commands.py
+++ b/fixieai/cli/session/commands.py
@@ -9,6 +9,7 @@ def validate_agent_exists(ctx, param, agent_id):
         agent = client.get_agent(agent_id)
         if not agent.valid:
             raise click.BadParameter(f"Agent {agent_id} does not exist")
+    return agent_id
 
 
 @click.group(help="Session-related commands.")
@@ -34,6 +35,8 @@ def web_option(func):
 
 
 @session.command("new", help="Creates a new session and opens it.")
+@click.argument("message", required=False)
+@web_option
 @click.option(
     "-a",
     "--agent",
@@ -41,8 +44,6 @@ def web_option(func):
     callback=validate_agent_exists,
     help="A specific agent to talk to. If unset, `fixie` is used.",
 )
-@web_option
-@click.argument("message", required=False)
 @click.pass_context
 def new_session(ctx, agent, web, message):
     client = ctx.obj.client
@@ -56,9 +57,9 @@ def new_session(ctx, agent, web, message):
 
 
 @session.command("open", help="Opens a session.")
+@click.argument("session_id")
 @web_option
 @click.pass_context
-@click.argument("session_id")
 def open_session(ctx, web, session_id: str):
     client = ctx.obj.client
     session = client.get_session(session_id)


### PR DESCRIPTION
Add `--reload` option to `fixie agent serve` to automatically reload on agent implementation changes.