### PR TITLE
Add -o StrictHostKeyChecking=accept-new for tunnel

### DIFF
--- a/fixieai/cli/agent/tunnel.py
+++ b/fixieai/cli/agent/tunnel.py
@@ -20,6 +20,8 @@ class Tunnel:
                 "ssh",
                 "-R",
                 f"80:localhost:{self._port}",
+                "-o",
+                "StrictHostKeyChecking=accept-new",
                 "nokey@localhost.run",
                 "--",
                 "--output=json",


### PR DESCRIPTION
This avoid users needing to respond to the host key prompt on their first connection to localhost.run.