### PR TITLE
Make error message more clear when `serve()` is accidentally called during import

### DIFF
--- a/fixieai/agents/code_shot.py
+++ b/fixieai/agents/code_shot.py
@@ -4,7 +4,6 @@ import dataclasses
 import functools
 import inspect
 import json
-import os
 import re
 import threading
 import time
@@ -123,8 +122,7 @@ class CodeShotAgent:
     ):
         """Starts serving the current agent at `{host}:{port}` via uvicorn.
 
-        If agent_id is specified as an argument or via the FIXIE_REFRESH_AGENT_ID environment variable,
-        this pings Fixie upon startup to fetch the latest prompt and fewshots.
+        If agent_id is specified, this pings Fixie upon startup to fetch the latest prompt and fewshots.
 
         Args:
             agent_id: The qualified agent id (`username/handle`)
@@ -136,15 +134,14 @@ class CodeShotAgent:
     def app(self, agent_id: Optional[str] = None) -> fastapi.FastAPI:
         """Returns a fastapi.FastAPI application that serves the agent.
 
-        If agent_id is specified as an argument or via the FIXIE_REFRESH_AGENT_ID environment variable,
-        this pings Fixie upon startup to fetch the latest prompt and fewshots.
+        If agent_id is specified, this pings Fixie upon startup to fetch the latest prompt and fewshots.
 
         Args:
             agent_id: The qualified agent id (`username/handle`)
         """
         fast_api = fastapi.FastAPI()
         fast_api.include_router(self.api_router())
-        agent_id = agent_id or os.getenv("FIXIE_REFRESH_AGENT_ID")
+        agent_id = agent_id
         if agent_id:
             fast_api.add_event_handler(
                 "startup", functools.partial(_ping_fixie_async, agent_id)

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -252,9 +252,11 @@ def serve(ctx, path, host, port, tunnel, reload):
         )
 
         if reload:
+            # When using reload=True the only way to pass arguments is via environment variable.
+            os.environ["FIXIE_AGENT_PATH"] = path
             os.environ["FIXIE_REFRESH_AGENT_ID"] = agent_api.agent_id
             uvicorn.run(
-                config.entry_point + ".app",
+                "fixieai.cli.agent.loader:uvicorn_app_factory",
                 host=host,
                 port=port,
                 factory=True,

--- a/fixieai/cli/agent/loader.py
+++ b/fixieai/cli/agent/loader.py
@@ -17,11 +17,11 @@ def _ensure_serving_disabled():
             "agent.serve() must not be called while your agent is being imported."
         )
 
-    agents.CodeShotAgent.serve = _fail
+    agents.CodeShotAgent.serve = _fail  # type: ignore[assignment]
     try:
         yield
     finally:
-        agents.CodeShotAgent.serve = original_serve
+        agents.CodeShotAgent.serve = original_serve  # type: ignore[assignment]
 
 
 def load_agent_from_path(

--- a/fixieai/cli/agent/loader.py
+++ b/fixieai/cli/agent/loader.py
@@ -1,3 +1,4 @@
+import contextlib
 import importlib
 import os
 import sys
@@ -5,6 +6,22 @@ from typing import Tuple
 
 from fixieai import agents
 from fixieai.cli.agent import agent_config
+
+
+@contextlib.contextmanager
+def _ensure_serving_disabled():
+    original_serve = agents.CodeShotAgent.serve
+
+    def _fail(*_, **__):
+        raise RuntimeError(
+            "agent.serve() must not be called while your agent is being imported."
+        )
+
+    agents.CodeShotAgent.serve = _fail
+    try:
+        yield
+    finally:
+        agents.CodeShotAgent.serve = original_serve
 
 
 def load_agent_from_path(
@@ -23,5 +40,16 @@ def load_agent_from_path(
     module_name = entry_point_parts[0]
     attr = entry_point_parts[1] if len(entry_point_parts) == 2 else "agent"
 
-    module = importlib.import_module(module_name)
+    with _ensure_serving_disabled():
+        module = importlib.import_module(module_name)
     return config, getattr(module, attr)
+
+
+def uvicorn_app_factory():
+    """Returns an app that can be used to serve an agent with uvicorn.
+
+    The FIXIE_AGENT_PATH environment variable should be set if agent.yaml is not in the current directory.
+    The FIXIE_REFRESH_AGENT_ID environment variable can be set to trigger a refresh on startup.
+    """
+    _, impl = load_agent_from_path(os.getenv("FIXIE_AGENT_PATH", "."))
+    return impl.app(os.getenv("FIXIE_REFRESH_AGENT_ID"))


### PR DESCRIPTION
Our previous replit examples all had top-level calls to `.serve()` -- this changes the loader to temporarily monkey-patch `CodeShotAgent.serve` while the agent is imported to make these failures more straightforward to debug.

Since we need an environment variable to pass the path down, this also moves the other environment-variable plumbing done by #66 out of `CodeShotAgent` and into the CLI machinery.