### PR TITLE
Generate `requirements.txt` from `fixie init`

### DIFF
--- a/fixieai/__init__.py
+++ b/fixieai/__init__.py
@@ -1,3 +1,5 @@
+import importlib.metadata
+
 from fixieai.agents import AgentQuery
 from fixieai.agents import AgentResponse
 from fixieai.agents import CodeShotAgent
@@ -31,3 +33,5 @@ __all__ = [
     "get_embeds",
     "query",
 ]
+
+__version__ = importlib.metadata.version(__name__)

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -7,7 +7,7 @@ import re
 import shlex
 import urllib.request
 from contextlib import contextmanager
-from typing import BinaryIO, Dict
+from typing import BinaryIO, Dict, List
 
 import click
 import rich.console as rich_console
@@ -27,6 +27,10 @@ ENTRY_POINT_PATTERN = re.compile(rf"^{VAR_NAME_RE}(\.{VAR_NAME_RE})*:{VAR_NAME_R
 AGENT_TEMPLATE_URL = (
     "https://raw.githubusercontent.com/fixie-ai/fixie-examples/main/agents/template.py"
 )
+
+REQUIREMENTS_TXT = "requirements.txt"
+CURRENT_FIXIE_REQUIREMENT = f"fixieai ~= {fixieai.__version__}"
+FIXIE_REQUIREMENT_PATTERN = re.compile(r"^\s*fixieai([^\w]|$)")
 
 
 @click.group(help="Agent-related commands.")
@@ -63,6 +67,31 @@ def _validate_entry_point(ctx, param, value):
             return value
 
 
+def _update_agent_requirements(
+    existing_requirements: List[str], new_requirements: List[str]
+) -> List[str]:
+    """Returns an updated list of agent requirements to go in requirements.txt."""
+
+    # Ensure that a compatible version of the Fixie SDK is present.
+    resolved_requirements: List[str] = []
+
+    for existing_requirement in existing_requirements:
+        # If there's already a different fixieai requirement, replace it.
+        if (
+            re.match(FIXIE_REQUIREMENT_PATTERN, existing_requirement)
+            and existing_requirement != CURRENT_FIXIE_REQUIREMENT
+        ):
+            pass
+        else:
+            resolved_requirements.append(existing_requirement)
+
+    for new_requirement in [CURRENT_FIXIE_REQUIREMENT] + new_requirements:
+        if new_requirement not in resolved_requirements:
+            resolved_requirements.append(new_requirement)
+
+    return resolved_requirements
+
+
 @agent.command("init", help="Creates an agent.yaml file.")
 @click.option(
     "--handle",
@@ -93,7 +122,13 @@ def _validate_entry_point(ctx, param, value):
     default=lambda: _current_config().public,
     type=click.BOOL,
 )
-def init_agent(handle, description, entry_point, more_info_url, public):
+@click.option(
+    "--requirement",
+    multiple=True,
+    type=str,
+    help="Additional requirements for requirements.txt. Can be specified multiple times.",
+)
+def init_agent(handle, description, entry_point, more_info_url, public, requirement):
     try:
         current_config = agent_config.load_config()
     except FileNotFoundError:
@@ -115,6 +150,50 @@ def init_agent(handle, description, entry_point, more_info_url, public):
         )
     else:
         click.secho(f"Initialized agent.yaml.", fg="green")
+
+    try:
+        with open(REQUIREMENTS_TXT, "rt") as requirements_txt:
+            existing_requirements = list(
+                r.strip() for r in requirements_txt.readlines()
+            )
+    except FileNotFoundError:
+        existing_requirements = []
+
+    resolved_requirements = _update_agent_requirements(
+        existing_requirements, list(requirement)
+    )
+    if not existing_requirements:
+        write_requirements = True
+    else:
+        new_requirements = [
+            r for r in resolved_requirements if r not in existing_requirements
+        ]
+        removed_requirements = [
+            r for r in existing_requirements if r not in resolved_requirements
+        ]
+
+        if new_requirements or removed_requirements:
+            click.secho(
+                f"{REQUIREMENTS_TXT} already exists.",
+                fg="yellow",
+            )
+            if new_requirements:
+                click.secho(
+                    f"The following requirements will be added: {new_requirements}",
+                    fg="yellow",
+                )
+            if removed_requirements:
+                click.secho(
+                    f"The following requirements will be removed: {removed_requirements}",
+                    fg="yellow",
+                )
+            write_requirements = click.confirm("Okay to proceed?", default=True)
+        else:
+            write_requirements = False
+
+    if write_requirements:
+        with open(REQUIREMENTS_TXT, "wt") as requirements_txt:
+            requirements_txt.writelines(r + "\n" for r in resolved_requirements)
 
 
 def _current_config() -> agent_config.AgentConfig:

--- a/fixieai/cli/agent/commands_test.py
+++ b/fixieai/cli/agent/commands_test.py
@@ -1,0 +1,30 @@
+from . import commands
+
+
+def test_update_agent_requirements_adds_fixie():
+    new_requirements = commands._update_agent_requirements([], [])
+    assert new_requirements == [commands.CURRENT_FIXIE_REQUIREMENT]
+
+
+def test_update_agent_requirements_honors_specified_fixie():
+    new_requirements = commands._update_agent_requirements([], ["fixieai"])
+    assert new_requirements == ["fixieai"]
+
+
+def test_update_agent_requirements_overrides_existing_fixie():
+    new_requirements = commands._update_agent_requirements(
+        ["fixieai", "fixieai == 0.0"], []
+    )
+    assert new_requirements == [commands.CURRENT_FIXIE_REQUIREMENT]
+
+
+def test_update_agent_requirements_combines():
+    new_requirements = commands._update_agent_requirements(
+        ["package1", "package2"], ["package2", "package3"]
+    )
+    assert new_requirements == [
+        "package1",
+        "package2",
+        commands.CURRENT_FIXIE_REQUIREMENT,
+        "package3",
+    ]


### PR DESCRIPTION
This adds support for generating `requirements.txt` via `fixie init`. The command now takes an optional `--requirement` argument (which can be specified multiple times) to include requirements in a `requirements.txt` file.

Even if no requirements are specified, the command will include a `fixieai` requirement specifier that is version-compatible with the user's SDK. (To facilitate this, this also adds `__version__` to the top-level `__init__.py`.)

If the file already exists, the arguments are taken as additions unless they are already present. If an existing `fixieai` requirement is specified that particular requirement will be _replaced_.