### PR TITLE
Make YAML formatting more natural to match existing samples

### DIFF
--- a/fixieai/cli/agent/agent_config.py
+++ b/fixieai/cli/agent/agent_config.py
@@ -16,10 +16,10 @@ class AgentConfig(utils.DataClassYamlMixin):
     """Represents an agent.yaml config file."""
 
     handle: str = dataclasses.field(default_factory=_current_dirname)
-    name: str = ""
+    name: Optional[str] = None
     description: str = ""
-    entry_point: str = "main:agent"
     more_info_url: str = ""
+    entry_point: str = "main:agent"
     deployment_url: Optional[str] = None
     public: bool = False
 

--- a/fixieai/cli/utils.py
+++ b/fixieai/cli/utils.py
@@ -1,9 +1,28 @@
-from typing import TextIO, Type, TypeVar, Union
+import dataclasses
+from typing import Any, MutableMapping, TextIO, Type, TypeVar, Union
 
 import dataclasses_json
 import yaml
 
 A = TypeVar("A", bound="DataClassYamlMixin")
+
+
+class _NicelyFormattedYAMLString:
+    """A string wrapper that formats multiline strings more nicely."""
+
+    def __init__(self, value: str):
+        self.value = value
+
+    def dump(self, dumper: yaml.Dumper) -> yaml.Node:
+        return dumper.represent_scalar(
+            "tag:yaml.org,2002:str", self.value, style="|" if "\n" in self.value else ""
+        )
+
+
+yaml.add_representer(
+    _NicelyFormattedYAMLString,
+    lambda dumper, value: value.dump(dumper),
+)
 
 
 class DataClassYamlMixin(dataclasses_json.DataClassJsonMixin):
@@ -12,4 +31,14 @@ class DataClassYamlMixin(dataclasses_json.DataClassJsonMixin):
         return cls.from_dict(yaml.safe_load(config))
 
     def to_yaml(self) -> str:
-        return yaml.dump(self.to_dict(), sort_keys=False)  # type: ignore
+        as_dict: MutableMapping[str, Any] = self.to_dict()
+
+        # Exclude any keys whose values and default values are None.
+        for field in dataclasses.fields(self):
+            value = as_dict[field.name]
+            if value is None and field.default is None:
+                del as_dict[field.name]
+            elif isinstance(value, str):
+                as_dict[field.name] = _NicelyFormattedYAMLString(value)
+
+        return yaml.dump(as_dict, sort_keys=False)  # type: ignore

--- a/fixieai/cli/utils_test.py
+++ b/fixieai/cli/utils_test.py
@@ -1,0 +1,24 @@
+import dataclasses
+from typing import Optional
+
+from . import utils
+
+
+def test_yaml_formatting():
+    @dataclasses.dataclass
+    class C(utils.DataClassYamlMixin):
+        string: str = "default value"
+        optional: Optional[str] = None
+
+    defaults = C()
+    assert defaults.to_yaml() == "string: default value\n"
+
+    with_optional = C(optional="optional value")
+    assert (
+        with_optional.to_yaml() == "string: default value\noptional: optional value\n"
+    )
+
+    multiline = C(string="line1\nline2\n", optional="optional value")
+    assert (
+        multiline.to_yaml() == "string: |\n  line1\n  line2\noptional: optional value\n"
+    )

--- a/fixieai/client/agent.py
+++ b/fixieai/client/agent.py
@@ -227,7 +227,7 @@ class Agent:
 
     def create_agent(
         self,
-        name: str,
+        name: Optional[str],
         description: str,
         query_url: Optional[str] = None,
         func_url: Optional[str] = None,
@@ -239,7 +239,7 @@ class Agent:
             """
             mutation CreateAgent(
                 $handle: String!,
-                $name: String!,
+                $name: String,
                 $description: String!,
                 $queryUrl: String,
                 $funcUrl: String,
@@ -265,7 +265,8 @@ class Agent:
         )
 
         variable_values: Dict[str, Any] = {"handle": self._handle}
-        variable_values["name"] = name
+        if name is not None:
+            variable_values["name"] = name
         variable_values["description"] = description
         if query_url is not None:
             variable_values["queryUrl"] = query_url


### PR DESCRIPTION
This changes `agent.yaml` formatting to:

- Exclude `None`-valued fields whose defaults are also `None` (namely `name` and `deployment_url`)
- Serialize strings using `|` if and only if they are multiline
- Reorder `more_info_url` and `entry_point`

With these change `fixie init` produces YAML files similar to those in the fixie-examples repo.