### PR TITLE
Fix tunnel port binding on Windows, path bug

### DIFF
--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -333,7 +333,7 @@ def serve(ctx, path, host, port, tunnel, reload):
             console.print(
                 f"[yellow]This replaces any existing deployment, run [bold]fixie deploy[/bold] to redeploy to prod.[/yellow]"
             )
-            config.deployment_url = stack.enter_context(tunnel_.Tunnel(host, port))
+            config.deployment_url = stack.enter_context(tunnel_.Tunnel(port))
 
         agent_api = _ensure_agent_updated(ctx.obj.client, config)
         console.print(
@@ -345,7 +345,7 @@ def serve(ctx, path, host, port, tunnel, reload):
 
         if reload:
             # When using reload=True the only way to pass arguments is via environment variable.
-            os.environ["FIXIE_AGENT_PATH"] = path
+            os.environ["FIXIE_AGENT_PATH"] = "."
             os.environ["FIXIE_REFRESH_AGENT_ID"] = agent_api.agent_id
             uvicorn.run(
                 "fixieai.cli.agent.loader:uvicorn_app_factory",

--- a/fixieai/cli/agent/tunnel.py
+++ b/fixieai/cli/agent/tunnel.py
@@ -10,8 +10,7 @@ class Tunnel:
     Shuts down the tunnel when the context manager exits.
     """
 
-    def __init__(self, host: str, port: int):
-        self._host = host
+    def __init__(self, port: int):
         self._port = port
 
     def __enter__(self):
@@ -19,7 +18,8 @@ class Tunnel:
             [
                 "ssh",
                 "-R",
-                f"80:localhost:{self._port}",
+                # N.B. 127.0.0.1 must be used on Windows (not localhost or 0.0.0.0)
+                f"80:127.0.0.1:{self._port}",
                 "-o",
                 "StrictHostKeyChecking=accept-new",
                 "nokey@localhost.run",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fixieai"
-version = "0.2.3"
+version = "0.2.4"
 description = "SDK for the Fixie.ai platform. See: https://fixie.ai"
 authors = ["Fixie.ai Team <hello@fixie.ai>"]
 packages = [


### PR DESCRIPTION
Empirically `ssh` on Windows requires `127.0.0.1` to correctly tunnel; use that instead of localhost -- this is consistent with discussion on [StackOverflow](https://stackoverflow.com/a/67203173).

Also fix a bug where `fixie serve --reload` does not work correctly when not in the `agent.yaml`'s directory.

