### PR TITLE
Add agent validation to serve/deploy

### DIFF
--- a/fixieai/agents/code_shot.py
+++ b/fixieai/agents/code_shot.py
@@ -114,7 +114,6 @@ class CodeShotAgent:
             self.register_func(_oauth)
 
         utils.strip_prompt_lines(self)
-        utils.validate_code_shot_agent(self)
 
     def serve(
         self, agent_id: Optional[str] = None, host: str = "0.0.0.0", port: int = 8181

--- a/fixieai/cli/agent/agent_config.py
+++ b/fixieai/cli/agent/agent_config.py
@@ -29,12 +29,11 @@ def normalize_path(path: Optional[str] = None) -> str:
 
     Args:
         path: Optional path to either a directory or YAML file. If unspecified,
-            will return "{cwd}/agent.yaml".
+            will return "agent.yaml".
     """
-    if path is None:
-        path = os.getcwd()
-
-    if os.path.isdir(path):
+    if not path:
+        path = "agent.yaml"
+    elif os.path.isdir(path):
         path = os.path.join(path, "agent.yaml")
 
     return path

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -491,7 +491,7 @@ def _tarinfo_filter(
     "validate",
     is_flag=True,
     default=True,
-    help="(default enabled) Validate that the agent loads locally before deploying",
+    help="(default enabled) Validate that the agent loads in a local venv before deploying",
 )
 @click.pass_context
 def deploy(ctx, path, metadata_only, validate):

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -384,8 +384,8 @@ def _validate_agent_loads_or_exit(
     "--venv/--no-venv",
     "use_venv",
     is_flag=True,
-    default=True,
-    help="(default enabled) Run from virtual environment",
+    default=False,
+    help="Run from virtual environment",
 )
 @click.pass_context
 def serve(ctx, path, host, port, use_tunnel, reload, use_venv):

--- a/fixieai/cli/agent/loader.py
+++ b/fixieai/cli/agent/loader.py
@@ -58,5 +58,6 @@ def uvicorn_app_factory():
 
 
 if __name__ == "__main__":
-    # Load the agent to make sure it can successfully be loaded.
+    # Load the agent (typically within an agent-specific venv) to ensure the Python module can be loaded
+    # without errors. See `fixie agent serve` and `fixie agent deploy --validate`.
     load_agent_from_path(".")


### PR DESCRIPTION
This adds stricter agent validation to `fixie serve` and `fixie deploy`. In particular:
- Agents now run from within their own virtual environment in which dependencies from `requirements.txt` are installed
- `python -m fixieai.cli.agent.loader` now loads and validates the agent

This also moves fewshot validation out of the agent constructor and into `load_agent_from_path` so that it has the opportunity to run _after_ all funcs have been registered.