### PR TITLE
Bump SDK version to 0.2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fixieai"
-version = "0.2.4"
+version = "0.2.5"
 description = "SDK for the Fixie.ai platform. See: https://fixie.ai"
 authors = ["Fixie.ai Team <hello@fixie.ai>"]
 packages = [


### PR DESCRIPTION
New in this version: tarball deployments to accommodate larger agents