### PR TITLE
Add response chunking and auth token verification to `GET /`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -12,7 +12,7 @@ default: format check test build-docs
 
 # Install dependencies for local development.
 install:
-    pip install poetry
+    pip install poetry==1.2.1
     poetry install --sync
     poetry run mypy --install-types --non-interactive .
 

--- a/fixieai/agents/code_shot_test.py
+++ b/fixieai/agents/code_shot_test.py
@@ -1,4 +1,5 @@
 import dataclasses
+import os
 
 import fastapi
 import pytest
@@ -39,7 +40,8 @@ def mock_token_verifier(mocker):
 
 
 @pytest.fixture
-def dummy_agent():
+def dummy_agent(mocker):
+    mocker.patch.dict(os.environ, {"FIXIE_ALLOWED_AGENT_ID": "fake agent id"})
     agent = agents.CodeShotAgent(
         BASE_PROMPT,
         FEW_SHOTS,
@@ -55,7 +57,6 @@ def dummy_agent():
         llm_settings=agents.LlmSettings(
             model="test-model", temperature=0.42, maximum_tokens=42
         ),
-        allowed_agent_id="fake agent id",
     )
 
     @agent.register_func

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -550,8 +550,8 @@ def deploy(ctx, path, metadata_only, validate):
                 )
                 _add_text_file_to_tarfile(
                     ".env",
-                    "".join(
-                        f"{key}={value}\n"
+                    "\n".join(
+                        f"{key}={value}"
                         for key, value in {
                             FIXIE_ALLOWED_AGENT_ID: agent_id,
                             "FIXIE_API_URL": constants.FIXIE_API_URL,

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -554,6 +554,7 @@ def deploy(ctx, path, metadata_only, validate):
                         f"{key}={value}\n"
                         for key, value in {
                             FIXIE_ALLOWED_AGENT_ID: agent_id,
+                            "FIXIE_API_URL": constants.FIXIE_API_URL,
                         }.items()
                     ),
                     tarball,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1184,7 +1184,7 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "8b971556de179f4c96e9de62d83e9e777fc22146d0a1b5aa09539ed04cc46efd"
+content-hash = "6e199722ea4db87f50fd001e09275f74b66f7aafcbb258ad0e2d9407f73072b0"
 
 [metadata.files]
 anyio = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dataclasses-json = "^0.5.7"
 validators = "^0.20.0"
 oauth2-client = "^1.3.0"
 Pillow = "*"
+python-dotenv = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fixieai"
-version = "0.2.7"
+version = "0.2.8"
 description = "SDK for the Fixie.ai platform. See: https://fixie.ai"
 authors = ["Fixie.ai Team <hello@fixie.ai>"]
 packages = [


### PR DESCRIPTION
This adds response chunking and auth token verification to `GET /`. For auth token verification, in addition to verifying that the response has a valid Fixie request token we also verify that the agent ID in the token is the expected ID.

To avoid requiring that the agent ID be embedded in the _code_, the `fixie serve` and `fixie deploy` commands set the `FIXIE_ALLOWED_AGENT_ID` environment variable. The latter loads an `.env` file in the bootstrapping code. This environment variable is optional to avoid it being a breaking change -- we can make it required in the future. To avoid confusion between multiple uses of `agent_id` in `CodeShotAgent` this moves the refresh-on-startup logic entirely out of the agent implementation and into the agent loader where `fixie serve` can continue to use it.

Finally, to allow agents to be deployed against non-prod Fixie environments, this uses the new `.env` mechanism to set `FIXIE_API_URL` to match the environment that the agent is being deployed into.
