### PR TITLE
Add support for storing multiple auth tokens in fixie auth

### DIFF
--- a/fixieai/cli/auth/commands.py
+++ b/fixieai/cli/auth/commands.py
@@ -13,9 +13,9 @@ def validate_not_authed(ctx, param, force):
         # --force is set
         return
     try:
-        api_key = user_config.load_config().auth_token
-        if api_key is not None:
-            username = _get_username(api_key)
+        auth_token = user_config.load_config().auth_token
+        if auth_token is not None:
+            username = _get_username(auth_token)
             click.echo("Already authenticated as ", nl=False)
             click.secho(username, fg="green", nl=False, bold=True)
             click.echo(". Set --force to force re-authentication.")
@@ -33,21 +33,21 @@ def validate_not_authed(ctx, param, force):
     expose_value=False,
 )
 def auth():
-    fixie_api_token = oauth_flow.oauth_flow()
+    fixie_auth_token = oauth_flow.oauth_flow()
     try:
         config = user_config.load_config()
     except FileNotFoundError:
         config = user_config.UserConfig()
 
-    config.auth_token = fixie_api_token
+    config.auth_token = fixie_auth_token
     user_config.save_config(config)
 
-    username = _get_username(fixie_api_token)
+    username = _get_username(fixie_auth_token)
     click.secho("Success! You're authenticated as ", fg="green", bold=True, nl=False)
     click.secho(username, fg="magenta", nl=False, bold=True)
     click.secho(".")
 
 
-def _get_username(api_key: str) -> str:
-    """Gets the username for an api_key."""
-    return client.FixieClient(api_key).get_current_username()
+def _get_username(auth_token: str) -> str:
+    """Gets the username for an auth token."""
+    return client.FixieClient(auth_token).get_current_username()

--- a/fixieai/cli/auth/commands.py
+++ b/fixieai/cli/auth/commands.py
@@ -13,7 +13,7 @@ def validate_not_authed(ctx, param, force):
         # --force is set
         return
     try:
-        api_key = user_config.load_config().api_key
+        api_key = user_config.load_config().auth_token
         if api_key is not None:
             username = _get_username(api_key)
             click.echo("Already authenticated as ", nl=False)
@@ -39,7 +39,7 @@ def auth():
     except FileNotFoundError:
         config = user_config.UserConfig()
 
-    config.api_key = fixie_api_token
+    config.auth_token = fixie_api_token
     user_config.save_config(config)
 
     username = _get_username(fixie_api_token)

--- a/fixieai/cli/auth/commands.py
+++ b/fixieai/cli/auth/commands.py
@@ -1,4 +1,5 @@
 import click
+from gql.transport import exceptions as gql_exceptions
 
 from fixieai.cli.auth import oauth_flow
 from fixieai.cli.auth import user_config
@@ -12,14 +13,14 @@ def validate_not_authed(ctx, param, force):
         # --force is set
         return
     try:
-        config = user_config.load_config()
-        if config.fixie_api_key is not None:
-            username = _get_username(config.fixie_api_key)
+        api_key = user_config.load_config().api_key
+        if api_key is not None:
+            username = _get_username(api_key)
             click.echo("Already authenticated as ", nl=False)
             click.secho(username, fg="green", nl=False, bold=True)
             click.echo(". Set --force to force re-authentication.")
             ctx.exit()
-    except FileNotFoundError:
+    except (FileNotFoundError, gql_exceptions.TransportQueryError):
         pass
 
 
@@ -38,7 +39,7 @@ def auth():
     except FileNotFoundError:
         config = user_config.UserConfig()
 
-    config.fixie_api_key = fixie_api_token
+    config.api_key = fixie_api_token
     user_config.save_config(config)
 
     username = _get_username(fixie_api_token)

--- a/fixieai/cli/auth/user_config.py
+++ b/fixieai/cli/auth/user_config.py
@@ -1,8 +1,20 @@
 import dataclasses
 import os
-from typing import Optional
+from typing import List, Optional
 
+from fixieai import constants
 from fixieai.cli import utils
+
+
+@dataclasses.dataclass
+class EnvironmentSpecificKey(utils.DataClassYamlMixin):
+    """Represents an API key bound to a specific environment."""
+
+    url: str
+    """The URL of the environment."""
+
+    api_key: str
+    """The API key for the environment."""
 
 
 @dataclasses.dataclass
@@ -10,6 +22,30 @@ class UserConfig(utils.DataClassYamlMixin):
     """Represents user config at ~/.config/fixie/config.yaml"""
 
     fixie_api_key: Optional[str] = None
+    """The default API key, will be used if no URL-specific key matches."""
+
+    environment_api_keys: List[EnvironmentSpecificKey] = dataclasses.field(
+        default_factory=lambda: [],
+    )
+    """Environment-specific API keys."""
+
+    @property
+    def api_key(self) -> Optional[str]:
+        for environment_key in self.environment_api_keys:
+            if environment_key.url == constants.FIXIE_API_URL:
+                return environment_key.api_key
+
+        # Otherwise return the default API key
+        return self.fixie_api_key
+
+    @api_key.setter
+    def api_key(self, value: str):
+        if self.api_key != value:
+            # Append it to the url-specific keys and make it the default
+            self.environment_api_keys.append(
+                EnvironmentSpecificKey(constants.FIXIE_API_URL, value)
+            )
+            self.fixie_api_key = value
 
 
 def load_config(path: Optional[str] = None) -> UserConfig:

--- a/fixieai/cli/auth/user_config_test.py
+++ b/fixieai/cli/auth/user_config_test.py
@@ -20,40 +20,40 @@ def config_with_environment():
     return user_config.UserConfig.from_dict(
         {
             "fixie_api_key": "default-token",
-            "environment_api_keys": [
-                {"url": EXAMPLE_URL, "api_key": "environment-token"}
+            "environment_auth_tokens": [
+                {"url": EXAMPLE_URL, "auth_token": "environment-token"}
             ],
         }
     )
 
 
 def test_user_config_no_env(config_without_environment):
-    assert config_without_environment.api_key == "default-token"
+    assert config_without_environment.auth_token == "default-token"
 
 
 def test_user_config_no_matching_env(config_with_environment):
-    assert config_with_environment.api_key == "default-token"
+    assert config_with_environment.auth_token == "default-token"
 
 
 def test_user_config_matching_env(mocker, config_with_environment):
     mocker.patch.object(constants, "FIXIE_API_URL", EXAMPLE_URL)
-    assert config_with_environment.api_key == "environment-token"
+    assert config_with_environment.auth_token == "environment-token"
 
 
 def test_set_token_multiple_environments(mocker, config_without_environment):
     url_1, token_1 = "https://test1.fixie.ai", "token1"
     mocker.patch.object(constants, "FIXIE_API_URL", url_1)
-    config_without_environment.api_key = token_1
-    assert config_without_environment.api_key == token_1
+    config_without_environment.auth_token = token_1
+    assert config_without_environment.auth_token == token_1
 
     url_2, token_2 = "https://test2.fixie.ai", "token2"
     mocker.patch.object(constants, "FIXIE_API_URL", url_2)
-    config_without_environment.api_key = token_2
-    assert config_without_environment.api_key == token_2
+    config_without_environment.auth_token = token_2
+    assert config_without_environment.auth_token == token_2
 
     # If we switch the URL back we should get the first token
     mocker.patch.object(constants, "FIXIE_API_URL", url_1)
-    assert config_without_environment.api_key == token_1
+    assert config_without_environment.auth_token == token_1
 
 
 def test_config_to_from_yaml(config_with_environment, config_without_environment):

--- a/fixieai/cli/auth/user_config_test.py
+++ b/fixieai/cli/auth/user_config_test.py
@@ -1,0 +1,67 @@
+import pytest
+
+from fixieai import constants
+from fixieai.cli.auth import user_config
+
+EXAMPLE_URL = "https://example.fixie.ai"
+
+
+@pytest.fixture
+def config_without_environment():
+    return user_config.UserConfig.from_dict(
+        {
+            "fixie_api_key": "default-token",
+        }
+    )
+
+
+@pytest.fixture
+def config_with_environment():
+    return user_config.UserConfig.from_dict(
+        {
+            "fixie_api_key": "default-token",
+            "environment_api_keys": [
+                {"url": EXAMPLE_URL, "api_key": "environment-token"}
+            ],
+        }
+    )
+
+
+def test_user_config_no_env(config_without_environment):
+    assert config_without_environment.api_key == "default-token"
+
+
+def test_user_config_no_matching_env(config_with_environment):
+    assert config_with_environment.api_key == "default-token"
+
+
+def test_user_config_matching_env(mocker, config_with_environment):
+    mocker.patch.object(constants, "FIXIE_API_URL", EXAMPLE_URL)
+    assert config_with_environment.api_key == "environment-token"
+
+
+def test_set_token_multiple_environments(mocker, config_without_environment):
+    url_1, token_1 = "https://test1.fixie.ai", "token1"
+    mocker.patch.object(constants, "FIXIE_API_URL", url_1)
+    config_without_environment.api_key = token_1
+    assert config_without_environment.api_key == token_1
+
+    url_2, token_2 = "https://test2.fixie.ai", "token2"
+    mocker.patch.object(constants, "FIXIE_API_URL", url_2)
+    config_without_environment.api_key = token_2
+    assert config_without_environment.api_key == token_2
+
+    # If we switch the URL back we should get the first token
+    mocker.patch.object(constants, "FIXIE_API_URL", url_1)
+    assert config_without_environment.api_key == token_1
+
+
+def test_config_to_from_yaml(config_with_environment, config_without_environment):
+    assert (
+        user_config.UserConfig.from_yaml(config_without_environment.to_yaml())
+        == config_without_environment
+    )
+    assert (
+        user_config.UserConfig.from_yaml(config_with_environment.to_yaml())
+        == config_with_environment
+    )

--- a/fixieai/cli/utils.py
+++ b/fixieai/cli/utils.py
@@ -35,6 +35,10 @@ class DataClassYamlMixin(dataclasses_json.DataClassJsonMixin):
 
         # Exclude any keys whose values and default values are None.
         for field in dataclasses.fields(self):
+            if field.name not in as_dict:
+                # Not all fields serialize to their Python names, leave them as-is.
+                continue
+
             value = as_dict[field.name]
             if value is None and field.default is None:
                 del as_dict[field.name]

--- a/fixieai/cli/utils.py
+++ b/fixieai/cli/utils.py
@@ -28,7 +28,7 @@ yaml.add_representer(
 class DataClassYamlMixin(dataclasses_json.DataClassJsonMixin):
     @classmethod
     def from_yaml(cls: Type[A], config: Union[str, TextIO]) -> A:
-        return cls.from_dict(yaml.safe_load(config))
+        return cls.from_dict(yaml.safe_load(config) or {})
 
     def to_yaml(self) -> str:
         as_dict: MutableMapping[str, Any] = self.to_dict()

--- a/fixieai/constants.py
+++ b/fixieai/constants.py
@@ -3,8 +3,6 @@ and your Fixie API key."""
 
 import os
 
-import yaml
-
 # Base Fixie platform URL.
 FIXIE_API_URL = os.getenv("FIXIE_API_URL", "https://app.fixie.ai")
 # Path to fixie config file.
@@ -42,10 +40,11 @@ def fixie_api_key() -> str:
     if "FIXIE_API_KEY" in os.environ:
         return os.environ["FIXIE_API_KEY"]
     try:
-        with open(FIXIE_CONFIG_PATH) as fp:
-            api_key = yaml.safe_load(fp)["fixie_api_key"]
-            assert isinstance(api_key, str)
-            return api_key
+        from fixieai.cli.auth import user_config
+
+        api_key = user_config.load_config().api_key
+        assert isinstance(api_key, str)
+        return api_key
     except (FileNotFoundError, KeyError, AssertionError):
         raise PermissionError(
             "User is not authenticated. Run 'fixie auth' to authenticate, or set the "

--- a/fixieai/constants.py
+++ b/fixieai/constants.py
@@ -29,7 +29,7 @@ FIXIE_AGENT_API_AUDIENCES = ["https://app.fixie.ai/api", "https://app.dev.fixie.
 
 
 def fixie_api_key() -> str:
-    """Returns authenticated user's fixie api key.
+    """Returns authenticated user's fixie auth token.
 
     User may authenticate via `fixie auth`, or by setting FIXIE_API_KEY environment
     variable to override any previous authentication.
@@ -42,9 +42,9 @@ def fixie_api_key() -> str:
     try:
         from fixieai.cli.auth import user_config
 
-        api_key = user_config.load_config().api_key
-        assert isinstance(api_key, str)
-        return api_key
+        auth_token = user_config.load_config().auth_token
+        assert isinstance(auth_token, str)
+        return auth_token
     except (FileNotFoundError, KeyError, AssertionError):
         raise PermissionError(
             "User is not authenticated. Run 'fixie auth' to authenticate, or set the "


### PR DESCRIPTION
This adds support for multiple auth tokens being stored in the Fixie CLI config. The config contains a default API token as well as a number of URL-specific tokens:

- When looking for a token we first check if there's a token specific to the current Fixie URL and fall back to the default token
- When updating the token we add the token to the host-specific tokens list _as well as the default token_. This means that for any previously-unseen URL, the last token recorded by `fixie auth` will be used.