### PR TITLE
Restore query.access_token setting

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -18,7 +18,7 @@ install:
 
 # Format code.
 format:
-    poetry run autoflake . --remove-all-unused-imports --quiet --in-place -r --exclude third_party
+    poetry run autoflake . --remove-all-unused-imports --quiet --in-place -r --exclude third_party  --exclude fixie-examples
     poetry run isort . --force-single-line-imports
     poetry run black .
 
@@ -26,7 +26,7 @@ format:
 check:
     poetry run black . --check
     poetry run isort . --check --force-single-line-imports
-    poetry run autoflake . --check --quiet --remove-all-unused-imports -r --exclude third_party
+    poetry run autoflake . --check --quiet --remove-all-unused-imports -r --exclude third_party --exclude fixie-examples
     poetry run mypy .
 
 # Run all tests.

--- a/fixieai/agents/standalone.py
+++ b/fixieai/agents/standalone.py
@@ -54,7 +54,9 @@ class StandaloneAgent(agent_base.AgentBase):
         """Verifies the request is a valid request from Fixie, and dispatches it to
         the appropriate function.
         """
-        token_claims = self.validate_token(credentials)
+        token_claims = self.validate_token_and_update_query_access_token(
+            query, credentials
+        )
 
         kwargs = self.get_func_kwargs(
             query,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fixieai"
-version = "0.2.10"
+version = "0.2.11"
 description = "SDK for the Fixie.ai platform. See: https://fixie.ai"
 authors = ["Fixie.ai Team <hello@fixie.ai>"]
 packages = [


### PR DESCRIPTION
As part of a refactoring, #104 dropped copying the token over to `query.access_token`. This restores it.