### PR TITLE
fixed valid empty first line of fewshot bug

### DIFF
--- a/fixieai/agents/code_shot.py
+++ b/fixieai/agents/code_shot.py
@@ -92,8 +92,14 @@ class CodeShotAgent(agent_base.AgentBase):
 
 def _split_few_shots(few_shots: str) -> List[str]:
     """Split a long string of all few-shots into a list of few-shot strings."""
-    lines = few_shots.splitlines()
+    # First, strip all lines to remove bad spaces.
+    few_shots = "\n".join(line.strip() for line in few_shots.splitlines())
+    # Then, split by "\n\nQ:".
+    few_shot_splits = few_shots.split("\n\nQ:")
+    few_shot_splits = [few_shot_splits[0]] + [
+        "Q:" + few_shot for few_shot in few_shot_splits[1:]
+    ]
 
     def not_empty(s):
         return s != ""
-    return list(filter(not_empty, lines))
+    return list(filter(not_empty, few_shot_splits))

--- a/fixieai/agents/code_shot.py
+++ b/fixieai/agents/code_shot.py
@@ -100,6 +100,4 @@ def _split_few_shots(few_shots: str) -> List[str]:
         "Q:" + few_shot for few_shot in few_shot_splits[1:]
     ]
 
-    def not_empty(s):
-        return s != ""
-    return list(filter(not_empty, few_shot_splits))
+    return [few_shot for few_shot in few_shot_splits if few_shot]

--- a/fixieai/agents/code_shot.py
+++ b/fixieai/agents/code_shot.py
@@ -92,11 +92,8 @@ class CodeShotAgent(agent_base.AgentBase):
 
 def _split_few_shots(few_shots: str) -> List[str]:
     """Split a long string of all few-shots into a list of few-shot strings."""
-    # First, strip all lines to remove bad spaces.
-    few_shots = "\n".join(line.strip() for line in few_shots.splitlines())
-    # Then, split by "\n\nQ:".
-    few_shot_splits = few_shots.split("\n\nQ:")
-    few_shot_splits = [few_shot_splits[0]] + [
-        "Q:" + few_shot for few_shot in few_shot_splits[1:]
-    ]
-    return few_shot_splits
+    lines = few_shots.splitlines()
+
+    def not_empty(s):
+        return s != ""
+    return list(filter(not_empty, lines))

--- a/fixieai/agents/utils.py
+++ b/fixieai/agents/utils.py
@@ -29,11 +29,10 @@ def strip_prompt_lines(agent: code_shot.CodeShotAgent):
 def validate_code_shot_agent(agent: code_shot.CodeShotAgent):
     """A client-side validation of few_shots and agent."""
     _validate_base_prompt(agent.base_prompt)
-    for fewshot in agent.few_shots:
-        if fewshot is not "":
-            _validate_few_shot_prompt(
-                fewshot, agent.conversational, agent.is_valid_func_name
-            )
+
+    _validate_few_shot_lines(
+        agent.few_shots, agent.conversational, agent.is_valid_func_name
+    )
 
 
 def validate_registered_pyfunc(func: Callable, agent: agent_base.AgentBase):
@@ -172,11 +171,10 @@ class FewshotLinePattern(enum.Enum):
         return match
 
 
-def _validate_few_shot_prompt(
-    prompt: str, conversational: bool, is_valid_func_name: Callable[[str], bool]
+def _validate_few_shot_lines(
+    lines: List[str], conversational: bool, is_valid_func_name: Callable[[str], bool]
 ):
     """Validates 'prompt' as a correctly formatted few shot prompt."""
-    lines = prompt.splitlines(False)
 
     # Check that no line starts or ends in a whitespace.
     whitespaces = (" ", "\t", "\r")
@@ -187,12 +185,9 @@ def _validate_few_shot_prompt(
     ]
     _assert(
         not bad_lines,
-        f"Some lines in the fewshot start or end in whitespaces: {bad_lines!r}.",
-        prompt,
+        f"Some lines in the fewshot start or end in whitespaces",
+        ''.join(bad_lines),
     )
-
-    # Check that it doesn't end with newline
-    _assert(not prompt.endswith("\n"), "Fewshot ends with newline.", prompt)
 
     # Check that fewshot starts with a Q:, ends in an A:, and a Func says and Agent
     # says follows every Ask Func and Ask Agent.
@@ -201,47 +196,54 @@ def _validate_few_shot_prompt(
         pattern_matches[0] is not None
         and pattern_matches[0].re is FewshotLinePattern.QUERY.value,
         "Fewshot must start with a 'Q:'",
-        prompt,
+        lines[0],
     )
     last_pattern = FewshotLinePattern.QUERY
+    last_pattern_line = ''
     known_embeds: Set[str] = set()
 
     for i, (match, line) in enumerate(zip(pattern_matches, lines)):
+
         pattern = (
             FewshotLinePattern(match.re)
             if match is not None
             else FewshotLinePattern.NO_PATTERN
         )
 
+        # Check that it doesn't end with newline
+        _assert(not line.endswith("\n"), "Fewshot ends with newline.", lines)
+
         if pattern is FewshotLinePattern.ASK_AGENT:
             assert match is not None
             next_match = (
-                pattern_matches[i + 1] if i + 1 < len(pattern_matches) else None
+                pattern_matches[i + 1] if i +
+                1 < len(pattern_matches) else None
             )
             _assert(
                 next_match is not None
                 and next_match.re is FewshotLinePattern.AGENT_SAYS.value
                 and match.group("agent_id") == next_match.group("agent_id"),
                 "Each 'Ask Agent' line must be immediately followed by an 'Agent says' line that references the same ",
-                prompt,
+                line,
             )
 
         if pattern is FewshotLinePattern.ASK_FUNC:
             assert match is not None
             next_match = (
-                pattern_matches[i + 1] if i + 1 < len(pattern_matches) else None
+                pattern_matches[i + 1] if i +
+                1 < len(pattern_matches) else None
             )
             _assert(
                 next_match is not None
                 and next_match.re is FewshotLinePattern.FUNC_SAYS.value
                 and match.group("func_name") == next_match.group("func_name"),
                 "Each 'Ask Func' line must be immediately followed by an 'Func says' line that references the same func.",
-                prompt,
+                line,
             )
             _assert(
                 is_valid_func_name(match.group("func_name")),
                 "Each 'Ask Func' line must reference a valid func name.",
-                prompt,
+                line,
             )
 
         if pattern is FewshotLinePattern.FUNC_SAYS:
@@ -249,11 +251,12 @@ def _validate_few_shot_prompt(
             _assert(
                 is_valid_func_name(match.group("func_name")),
                 "Each 'Func says' line must reference a valid func name.",
-                prompt,
+                line,
             )
 
         if pattern is not FewshotLinePattern.NO_PATTERN:
             last_pattern = pattern
+            last_pattern_line = line
 
         # Check that any embeds are valid.
         for embed_match in EMBED_REF.finditer(line):
@@ -267,14 +270,14 @@ def _validate_few_shot_prompt(
                         FewshotLinePattern.RESPONSE,
                     ),
                     "New embeds may not be introduced in Ask Agent, Ask Func, or A: lines.",
-                    prompt,
+                    linee,
                 )
                 known_embeds.add(key)
 
     _assert(
         last_pattern is FewshotLinePattern.RESPONSE,
         f"Fewshot must end with a 'A:' pattern, but it ends with {last_pattern}",
-        prompt,
+        last_pattern_line,
     )
 
     # Check that there's Q: and A: lines are interleaved.
@@ -289,18 +292,11 @@ def _validate_few_shot_prompt(
     ]
     qa_str = "".join(all_qa_lines)
 
-    if conversational:
-        _assert(
-            re.match("^(Qx*A)+$", qa_str) is not None,
-            "Each fewshot must have interleaved Q: and A: patterns when conversational=True",
-            prompt,
-        )
-    else:
-        _assert(
-            re.match("^Qx*A$", qa_str) is not None,
-            "Each fewshot must have exactly one Q: and A: pattern when conversational=False",
-            prompt,
-        )
+    _assert(
+        re.match("^(Qx*A)+$", qa_str) is not None,
+        "Each fewshot must have interleaved Q: and A",
+        qa_str,
+    )
 
 
 def _assert(condition: bool, msg: str, prompt: str):

--- a/fixieai/agents/utils.py
+++ b/fixieai/agents/utils.py
@@ -30,9 +30,10 @@ def validate_code_shot_agent(agent: code_shot.CodeShotAgent):
     """A client-side validation of few_shots and agent."""
     _validate_base_prompt(agent.base_prompt)
     for fewshot in agent.few_shots:
-        _validate_few_shot_prompt(
-            fewshot, agent.conversational, agent.is_valid_func_name
-        )
+        if fewshot is not "":
+            _validate_few_shot_prompt(
+                fewshot, agent.conversational, agent.is_valid_func_name
+            )
 
 
 def validate_registered_pyfunc(func: Callable, agent: agent_base.AgentBase):


### PR DESCRIPTION
When the first `fewshot` line is empty:
```python
FEW_SHOTS = """

Q: time
Ask Func[get_time]: input
Func[get_time] says: output
A: Now time is output
"""
```
, while run `fixie agent deploy` an incomprehensible error appeared:
```sh
...
Requirements installed successfully.
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/kol/Projects/fixie-agent/.fixie.venv/lib/python3.10/site-packages/fixieai/cli/agent/loader.py", line 95, in <module>
    load_agent_from_path(".")
  File "/home/kol/Projects/fixie-agent/.fixie.venv/lib/python3.10/site-packages/fixieai/cli/agent/loader.py", line 59, in load_agent_from_path
    agent_impl.validate()
  File "/home/kol/Projects/fixie-agent/.fixie.venv/lib/python3.10/site-packages/fixieai/agents/code_shot.py", line 90, in validate
    utils.validate_code_shot_agent(self)
  File "/home/kol/Projects/fixie-agent/.fixie.venv/lib/python3.10/site-packages/fixieai/agents/utils.py", line 34, in validate_code_shot_agent
    _validate_few_shot_prompt(
  File "/home/kol/Projects/fixie-agent/.fixie.venv/lib/python3.10/site-packages/fixieai/agents/utils.py", line 201, in _validate_few_shot_prompt
    pattern_matches[0] is not None
IndexError: list index out of range
Agent "trying" could not be loaded. If your agent requires additional dependencies make sure they are specified in ./requirements.txt.

```
Because this line https://github.com/fixie-ai/fixie-sdk/blob/877656079d31af882ec502e124a00592ab3c7b61/fixieai/agents/utils.py#L201 tried to access a non-existent object.

 This PR fixes this bug.