### PR TITLE
Use symlinks for venvs on non-Windows

### DIFF
--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -313,7 +313,8 @@ def _configure_venv(
     console.print(f"Configuring virtual environment in {venv_path}")
     python_exe = os.path.join(venv_path, "bin", "python")
     if not os.path.exists(python_exe):
-        venv.create(venv_path, with_pip=True)
+        # Match `python -m venv` behavior with symlinks on non-Windows to work around https://bugs.python.org/issue38705
+        venv.create(venv_path, with_pip=True, symlinks=os.name != "nt")
     requirements_txt_path = os.path.join(agent_dir, REQUIREMENTS_TXT)
     if not os.path.exists(requirements_txt_path):
         raise ValueError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fixieai"
-version = "0.2.13"
+version = "0.2.14"
 description = "SDK for the Fixie.ai platform. See: https://fixie.ai"
 authors = ["Fixie.ai Team <hello@fixie.ai>"]
 packages = [


### PR DESCRIPTION
Virtual environment creation with (some versions of) macOS system python fails SIGABRT. Per https://bugs.python.org/issue38705 this can be worked around by using `symlinks=True` when creating the virtual environment -- this changes the code to match `python -m venv` which uses symlinks for non-Windows OSes.