### PR TITLE
Add OpenAI proxy for agents

### DIFF
--- a/fixieai/agents/agent_base.py
+++ b/fixieai/agents/agent_base.py
@@ -23,7 +23,6 @@ from fixieai import constants
 from fixieai.agents import api
 from fixieai.agents import metadata as agent_metadata
 from fixieai.agents import oauth
-from fixieai.agents import openai_proxy
 from fixieai.agents import user_storage
 from fixieai.agents import utils
 
@@ -80,7 +79,6 @@ class AgentBase(abc.ABC):
         """Returns a fastapi.FastAPI application that serves the agent."""
         fast_api = fastapi.FastAPI()
         fast_api.include_router(self.api_router())
-        fast_api.add_middleware(openai_proxy.AuthTokenForwarderMiddleware)
 
         return fast_api
 

--- a/fixieai/agents/agent_base.py
+++ b/fixieai/agents/agent_base.py
@@ -23,6 +23,7 @@ from fixieai import constants
 from fixieai.agents import api
 from fixieai.agents import metadata as agent_metadata
 from fixieai.agents import oauth
+from fixieai.agents import openai_proxy
 from fixieai.agents import user_storage
 from fixieai.agents import utils
 
@@ -79,6 +80,7 @@ class AgentBase(abc.ABC):
         """Returns a fastapi.FastAPI application that serves the agent."""
         fast_api = fastapi.FastAPI()
         fast_api.include_router(self.api_router())
+        fast_api.add_middleware(openai_proxy.AuthTokenForwarderMiddleware)
 
         return fast_api
 

--- a/fixieai/agents/openai_proxy.py
+++ b/fixieai/agents/openai_proxy.py
@@ -1,12 +1,11 @@
 import contextvars
+import functools
 import logging
 import os
 import sys
 
-from starlette.middleware.base import BaseHTTPMiddleware
-
-import functools
 import wrapt
+from starlette.middleware.base import BaseHTTPMiddleware
 
 import fixieai.constants
 

--- a/fixieai/agents/openai_proxy.py
+++ b/fixieai/agents/openai_proxy.py
@@ -25,7 +25,7 @@ _current_request_token: contextvars.ContextVar[Optional[str]] = contextvars.Cont
 def enable_openai_proxy() -> bool:
     """Enables the Fixie OpenAI proxy for outbound OpenAI requests made in the context of an agent request.
 
-    Returns a value that indicates whether or not proxy is enabled. If either OPENAI_API_BASE or
+    Returns a value that indicates whether or not the proxy is enabled. If either OPENAI_API_BASE or
     OPENAI_API_KEY is already set, the proxy will not be enabled.
 
     The OpenAIProxyRequestTokenForwarderMiddleware must be used for the proxy to use valid auth tokens.

--- a/fixieai/agents/openai_proxy.py
+++ b/fixieai/agents/openai_proxy.py
@@ -1,0 +1,66 @@
+import contextvars
+import logging
+import os
+import sys
+
+from starlette.middleware.base import BaseHTTPMiddleware
+
+import functools
+import wrapt
+
+import fixieai.constants
+
+FAKE_OPENAI_KEY = "sk-fixie-openai-key"
+
+logger = logging.getLogger(__name__)
+_auth_token = contextvars.ContextVar("openai_proxy.auth_token_ctx")
+
+
+def enable_openai_proxy() -> bool:
+    if "OPENAI_API_BASE" in os.environ or "OPENAI_API_KEY" in os.environ:
+        logger.warning(
+            "OpenAI proxy is not enabled; leave OPEN_API_BASE and OPENAI_API_KEY unset to use the Fixie OpenAI proxy."
+        )
+        return False
+
+    assert (
+        "openai" not in sys.modules
+    ), "OpenAI has already been loaded. The OpenAI proxy should be enabled before loading OpenAI."
+
+    def _patch_api_requestor(module):
+        original_init = module.APIRequestor.__init__
+
+        @functools.wraps(original_init)
+        def patched_init(self, *args, **kwargs):
+            original_init(self, *args, **kwargs)
+
+            if (
+                self.api_base == fixieai.constants.FIXIE_OPENAI_PROXY_URL
+                and self.api_key == FAKE_OPENAI_KEY
+            ):
+                self.api_key = _auth_token.get()
+                if self.api_key is None:
+                    raise ValueError("The Fixie auth token contextvar was not set.")
+
+        module.APIRequestor.__init__ = patched_init
+
+    wrapt.register_post_import_hook(_patch_api_requestor, "openai.api_requestor")
+    os.environ["OPENAI_API_BASE"] = fixieai.constants.FIXIE_OPENAI_PROXY_URL
+    os.environ["OPENAI_API_KEY"] = FAKE_OPENAI_KEY
+
+    return True
+
+
+class AuthTokenForwarderMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        BEARER_PREFIX = "Bearer "
+
+        authorization = request.headers.get("Authorization")
+        if authorization and authorization.startswith(BEARER_PREFIX):
+            reset_token = _auth_token.set(authorization[len(BEARER_PREFIX) :])
+            try:
+                return await call_next(request)
+            finally:
+                _auth_token.reset(reset_token)
+        else:
+            return await call_next(request)

--- a/fixieai/agents/openai_proxy.py
+++ b/fixieai/agents/openai_proxy.py
@@ -23,9 +23,17 @@ _current_request_token: contextvars.ContextVar[Optional[str]] = contextvars.Cont
 
 
 def enable_openai_proxy() -> bool:
+    """Enables the Fixie OpenAI proxy for outbound OpenAI requests made in the context of an agent request.
+
+    Returns a value that indicates whether or not proxy is enabled. If either OPENAI_API_BASE or
+    OPENAI_API_KEY is already set, the proxy will not be enabled.
+
+    The OpenAIProxyRequestTokenForwarderMiddleware must be used for the proxy to use valid auth tokens.
+    """
+
     if "OPENAI_API_BASE" in os.environ or "OPENAI_API_KEY" in os.environ:
         logger.warning(
-            "OpenAI proxy is not enabled; leave OPEN_API_BASE and OPENAI_API_KEY unset to use the Fixie OpenAI proxy."
+            "OpenAI proxy is not enabled; leave OPENAI_API_BASE and OPENAI_API_KEY unset to use the Fixie OpenAI proxy."
         )
         return False
 

--- a/fixieai/agents/openai_proxy_test.py
+++ b/fixieai/agents/openai_proxy_test.py
@@ -1,0 +1,54 @@
+from typing import Optional
+
+import fastapi
+from fastapi import testclient
+from starlette import responses
+
+from fixieai.agents import openai_proxy
+
+
+def test_authorization_token_middleware():
+    FAKE_TOKEN = "fixie-test-token"
+    app = fastapi.FastAPI()
+
+    @app.get("/")
+    async def test_endpoint(expected_token: Optional[str] = None):
+        assert openai_proxy._current_request_token.get() == expected_token
+
+    @app.get("/stream")
+    async def test_stream(count: int, expected_token: Optional[str] = None):
+        def _gen():
+            for _ in range(count):
+                assert openai_proxy._current_request_token.get() == expected_token
+                yield b"."
+
+        return responses.StreamingResponse(_gen(), status_code=200)
+
+    app.add_middleware(openai_proxy.OpenAIProxyRequestTokenForwarderMiddleware)
+
+    client = testclient.TestClient(app)
+    response = client.get(
+        f"/?expected_token=test1",
+        headers={"Authorization": f"Bearer test1"},
+    )
+    assert response.status_code == 200
+
+    response = client.get(f"/")
+    assert response.status_code == 200
+
+    response = client.get(
+        f"/?expected_token=test2",
+        headers={"Authorization": f"Bearer test2"},
+    )
+    assert response.status_code == 200
+
+    response = client.get("/stream?count=10")
+    assert response.status_code == 200
+    assert response.content == b"." * 10
+
+    response = client.get(
+        "/stream?count=10&expected_token=test-streaming",
+        headers={"Authorization": f"Bearer test-streaming"},
+    )
+    assert response.status_code == 200
+    assert response.content == b"." * 10

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -473,9 +473,10 @@ if __name__ == "__main__":
     os.chdir("agent")
 
     # N.B. Load the .dotenv file before loading the Fixie SDK
+    import uvicorn
+
     from fixieai.cli.agent import loader
-    config, agent = loader.load_agent_from_path(".")
-    agent.serve(port=int(os.getenv("PORT", "8080")))
+    uvicorn.run(loader.uvicorn_app_factory(), host="0.0.0.0", port=os.getenv("PORT", "8080"))
 """
 
 

--- a/fixieai/cli/agent/loader.py
+++ b/fixieai/cli/agent/loader.py
@@ -83,6 +83,7 @@ def uvicorn_app_factory():
     """
     config, impl = load_agent_from_path(".")
     fastapi_app = impl.app()
+    fastapi_app.add_middleware(openai_proxy.OpenAIProxyRequestTokenForwarderMiddleware)
 
     if os.getenv("FIXIE_REFRESH_ON_STARTUP") == "true":
         fastapi_app.add_event_handler(

--- a/fixieai/cli/agent/loader.py
+++ b/fixieai/cli/agent/loader.py
@@ -12,6 +12,7 @@ import dotenv
 import fixieai
 from fixieai import agents
 from fixieai.cli.agent import agent_config
+from fixieai.agents import openai_proxy
 
 
 @contextlib.contextmanager
@@ -42,6 +43,8 @@ def load_agent_from_path(
     dotenv_path = os.path.join(agent_dir, ".env")
     if os.path.exists(dotenv_path):
         dotenv.load_dotenv(dotenv_path)
+
+    openai_proxy.enable_openai_proxy()
 
     # Inject the agent directory into PYTHONPATH
     sys.path.insert(0, agent_dir)

--- a/fixieai/cli/agent/loader.py
+++ b/fixieai/cli/agent/loader.py
@@ -11,8 +11,8 @@ import dotenv
 
 import fixieai
 from fixieai import agents
-from fixieai.cli.agent import agent_config
 from fixieai.agents import openai_proxy
+from fixieai.cli.agent import agent_config
 
 
 @contextlib.contextmanager

--- a/fixieai/constants.py
+++ b/fixieai/constants.py
@@ -24,6 +24,8 @@ FIXIE_OAUTH_REDIRECT_URL = f"{FIXIE_API_URL}/oauth"
 FIXIE_DEPLOYMENT_URL = f"{FIXIE_API_URL}/api/deployments"
 # Fixie's JWKS URL.
 FIXIE_JWKS_URL = f"{FIXIE_API_URL}/.well-known/jwks.json"
+# Fixie's OpenAI Proxy URL.
+FIXIE_OPENAI_PROXY_URL = f"{FIXIE_API_URL}/api/openai-proxy/v1"
 # Valid audiences for Fixie's query JWTs.
 FIXIE_AGENT_API_AUDIENCES = ["https://app.fixie.ai/api", "https://app.dev.fixie.ai/api"]
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1135,6 +1135,14 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "wrapt"
+version = "1.15.0"
+description = "Module for decorators, wrappers and monkey patching."
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
 name = "yarl"
 version = "1.8.2"
 description = "Yet another URL library"
@@ -1161,7 +1169,7 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "722cee0a52f24f39e772193247387beed3f2aefddf30046008ccf4c417d17a62"
+content-hash = "81a54872255a9132585ef7a0dac1bf62f0a523942788d598039d4543481aca22"
 
 [metadata.files]
 anyio = [
@@ -2276,6 +2284,83 @@ websockets = [
     {file = "websockets-11.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:5d4f4b341100d313b08149d7031eb6d12738ac758b0c90d2f9be8675f401b019"},
     {file = "websockets-11.0.1-py3-none-any.whl", hash = "sha256:85b4127f7da332feb932eee833c70e5e1670469e8c9de7ef3874aa2a91a6fbb2"},
     {file = "websockets-11.0.1.tar.gz", hash = "sha256:369410925b240b30ef1c1deadbd6331e9cd865ad0b8966bf31e276cc8e0da159"},
+]
+wrapt = [
+    {file = "wrapt-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:ca1cccf838cd28d5a0883b342474c630ac48cac5df0ee6eacc9c7290f76b11c1"},
+    {file = "wrapt-1.15.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e826aadda3cae59295b95343db8f3d965fb31059da7de01ee8d1c40a60398b29"},
+    {file = "wrapt-1.15.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5fc8e02f5984a55d2c653f5fea93531e9836abbd84342c1d1e17abc4a15084c2"},
+    {file = "wrapt-1.15.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:96e25c8603a155559231c19c0349245eeb4ac0096fe3c1d0be5c47e075bd4f46"},
+    {file = "wrapt-1.15.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:40737a081d7497efea35ab9304b829b857f21558acfc7b3272f908d33b0d9d4c"},
+    {file = "wrapt-1.15.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:f87ec75864c37c4c6cb908d282e1969e79763e0d9becdfe9fe5473b7bb1e5f09"},
+    {file = "wrapt-1.15.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:1286eb30261894e4c70d124d44b7fd07825340869945c79d05bda53a40caa079"},
+    {file = "wrapt-1.15.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:493d389a2b63c88ad56cdc35d0fa5752daac56ca755805b1b0c530f785767d5e"},
+    {file = "wrapt-1.15.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:58d7a75d731e8c63614222bcb21dd992b4ab01a399f1f09dd82af17bbfc2368a"},
+    {file = "wrapt-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:21f6d9a0d5b3a207cdf7acf8e58d7d13d463e639f0c7e01d82cdb671e6cb7923"},
+    {file = "wrapt-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ce42618f67741d4697684e501ef02f29e758a123aa2d669e2d964ff734ee00ee"},
+    {file = "wrapt-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41d07d029dd4157ae27beab04d22b8e261eddfc6ecd64ff7000b10dc8b3a5727"},
+    {file = "wrapt-1.15.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:54accd4b8bc202966bafafd16e69da9d5640ff92389d33d28555c5fd4f25ccb7"},
+    {file = "wrapt-1.15.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fbfbca668dd15b744418265a9607baa970c347eefd0db6a518aaf0cfbd153c0"},
+    {file = "wrapt-1.15.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:76e9c727a874b4856d11a32fb0b389afc61ce8aaf281ada613713ddeadd1cfec"},
+    {file = "wrapt-1.15.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e20076a211cd6f9b44a6be58f7eeafa7ab5720eb796975d0c03f05b47d89eb90"},
+    {file = "wrapt-1.15.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a74d56552ddbde46c246b5b89199cb3fd182f9c346c784e1a93e4dc3f5ec9975"},
+    {file = "wrapt-1.15.0-cp310-cp310-win32.whl", hash = "sha256:26458da5653aa5b3d8dc8b24192f574a58984c749401f98fff994d41d3f08da1"},
+    {file = "wrapt-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:75760a47c06b5974aa5e01949bf7e66d2af4d08cb8c1d6516af5e39595397f5e"},
+    {file = "wrapt-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ba1711cda2d30634a7e452fc79eabcadaffedf241ff206db2ee93dd2c89a60e7"},
+    {file = "wrapt-1.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56374914b132c702aa9aa9959c550004b8847148f95e1b824772d453ac204a72"},
+    {file = "wrapt-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a89ce3fd220ff144bd9d54da333ec0de0399b52c9ac3d2ce34b569cf1a5748fb"},
+    {file = "wrapt-1.15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bbe623731d03b186b3d6b0d6f51865bf598587c38d6f7b0be2e27414f7f214e"},
+    {file = "wrapt-1.15.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3abbe948c3cbde2689370a262a8d04e32ec2dd4f27103669a45c6929bcdbfe7c"},
+    {file = "wrapt-1.15.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b67b819628e3b748fd3c2192c15fb951f549d0f47c0449af0764d7647302fda3"},
+    {file = "wrapt-1.15.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:7eebcdbe3677e58dd4c0e03b4f2cfa346ed4049687d839adad68cc38bb559c92"},
+    {file = "wrapt-1.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:74934ebd71950e3db69960a7da29204f89624dde411afbfb3b4858c1409b1e98"},
+    {file = "wrapt-1.15.0-cp311-cp311-win32.whl", hash = "sha256:bd84395aab8e4d36263cd1b9308cd504f6cf713b7d6d3ce25ea55670baec5416"},
+    {file = "wrapt-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:a487f72a25904e2b4bbc0817ce7a8de94363bd7e79890510174da9d901c38705"},
+    {file = "wrapt-1.15.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:4ff0d20f2e670800d3ed2b220d40984162089a6e2c9646fdb09b85e6f9a8fc29"},
+    {file = "wrapt-1.15.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9ed6aa0726b9b60911f4aed8ec5b8dd7bf3491476015819f56473ffaef8959bd"},
+    {file = "wrapt-1.15.0-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:896689fddba4f23ef7c718279e42f8834041a21342d95e56922e1c10c0cc7afb"},
+    {file = "wrapt-1.15.0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:75669d77bb2c071333417617a235324a1618dba66f82a750362eccbe5b61d248"},
+    {file = "wrapt-1.15.0-cp35-cp35m-win32.whl", hash = "sha256:fbec11614dba0424ca72f4e8ba3c420dba07b4a7c206c8c8e4e73f2e98f4c559"},
+    {file = "wrapt-1.15.0-cp35-cp35m-win_amd64.whl", hash = "sha256:fd69666217b62fa5d7c6aa88e507493a34dec4fa20c5bd925e4bc12fce586639"},
+    {file = "wrapt-1.15.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b0724f05c396b0a4c36a3226c31648385deb6a65d8992644c12a4963c70326ba"},
+    {file = "wrapt-1.15.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbeccb1aa40ab88cd29e6c7d8585582c99548f55f9b2581dfc5ba68c59a85752"},
+    {file = "wrapt-1.15.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:38adf7198f8f154502883242f9fe7333ab05a5b02de7d83aa2d88ea621f13364"},
+    {file = "wrapt-1.15.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:578383d740457fa790fdf85e6d346fda1416a40549fe8db08e5e9bd281c6a475"},
+    {file = "wrapt-1.15.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:a4cbb9ff5795cd66f0066bdf5947f170f5d63a9274f99bdbca02fd973adcf2a8"},
+    {file = "wrapt-1.15.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:af5bd9ccb188f6a5fdda9f1f09d9f4c86cc8a539bd48a0bfdc97723970348418"},
+    {file = "wrapt-1.15.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:b56d5519e470d3f2fe4aa7585f0632b060d532d0696c5bdfb5e8319e1d0f69a2"},
+    {file = "wrapt-1.15.0-cp36-cp36m-win32.whl", hash = "sha256:77d4c1b881076c3ba173484dfa53d3582c1c8ff1f914c6461ab70c8428b796c1"},
+    {file = "wrapt-1.15.0-cp36-cp36m-win_amd64.whl", hash = "sha256:077ff0d1f9d9e4ce6476c1a924a3332452c1406e59d90a2cf24aeb29eeac9420"},
+    {file = "wrapt-1.15.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5c5aa28df055697d7c37d2099a7bc09f559d5053c3349b1ad0c39000e611d317"},
+    {file = "wrapt-1.15.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a8564f283394634a7a7054b7983e47dbf39c07712d7b177b37e03f2467a024e"},
+    {file = "wrapt-1.15.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:780c82a41dc493b62fc5884fb1d3a3b81106642c5c5c78d6a0d4cbe96d62ba7e"},
+    {file = "wrapt-1.15.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e169e957c33576f47e21864cf3fc9ff47c223a4ebca8960079b8bd36cb014fd0"},
+    {file = "wrapt-1.15.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:b02f21c1e2074943312d03d243ac4388319f2456576b2c6023041c4d57cd7019"},
+    {file = "wrapt-1.15.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f2e69b3ed24544b0d3dbe2c5c0ba5153ce50dcebb576fdc4696d52aa22db6034"},
+    {file = "wrapt-1.15.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d787272ed958a05b2c86311d3a4135d3c2aeea4fc655705f074130aa57d71653"},
+    {file = "wrapt-1.15.0-cp37-cp37m-win32.whl", hash = "sha256:02fce1852f755f44f95af51f69d22e45080102e9d00258053b79367d07af39c0"},
+    {file = "wrapt-1.15.0-cp37-cp37m-win_amd64.whl", hash = "sha256:abd52a09d03adf9c763d706df707c343293d5d106aea53483e0ec8d9e310ad5e"},
+    {file = "wrapt-1.15.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cdb4f085756c96a3af04e6eca7f08b1345e94b53af8921b25c72f096e704e145"},
+    {file = "wrapt-1.15.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:230ae493696a371f1dbffaad3dafbb742a4d27a0afd2b1aecebe52b740167e7f"},
+    {file = "wrapt-1.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63424c681923b9f3bfbc5e3205aafe790904053d42ddcc08542181a30a7a51bd"},
+    {file = "wrapt-1.15.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d6bcbfc99f55655c3d93feb7ef3800bd5bbe963a755687cbf1f490a71fb7794b"},
+    {file = "wrapt-1.15.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c99f4309f5145b93eca6e35ac1a988f0dc0a7ccf9ccdcd78d3c0adf57224e62f"},
+    {file = "wrapt-1.15.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b130fe77361d6771ecf5a219d8e0817d61b236b7d8b37cc045172e574ed219e6"},
+    {file = "wrapt-1.15.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:96177eb5645b1c6985f5c11d03fc2dbda9ad24ec0f3a46dcce91445747e15094"},
+    {file = "wrapt-1.15.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d5fe3e099cf07d0fb5a1e23d399e5d4d1ca3e6dfcbe5c8570ccff3e9208274f7"},
+    {file = "wrapt-1.15.0-cp38-cp38-win32.whl", hash = "sha256:abd8f36c99512755b8456047b7be10372fca271bf1467a1caa88db991e7c421b"},
+    {file = "wrapt-1.15.0-cp38-cp38-win_amd64.whl", hash = "sha256:b06fa97478a5f478fb05e1980980a7cdf2712015493b44d0c87606c1513ed5b1"},
+    {file = "wrapt-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2e51de54d4fb8fb50d6ee8327f9828306a959ae394d3e01a1ba8b2f937747d86"},
+    {file = "wrapt-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0970ddb69bba00670e58955f8019bec4a42d1785db3faa043c33d81de2bf843c"},
+    {file = "wrapt-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76407ab327158c510f44ded207e2f76b657303e17cb7a572ffe2f5a8a48aa04d"},
+    {file = "wrapt-1.15.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cd525e0e52a5ff16653a3fc9e3dd827981917d34996600bbc34c05d048ca35cc"},
+    {file = "wrapt-1.15.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d37ac69edc5614b90516807de32d08cb8e7b12260a285ee330955604ed9dd29"},
+    {file = "wrapt-1.15.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:078e2a1a86544e644a68422f881c48b84fef6d18f8c7a957ffd3f2e0a74a0d4a"},
+    {file = "wrapt-1.15.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:2cf56d0e237280baed46f0b5316661da892565ff58309d4d2ed7dba763d984b8"},
+    {file = "wrapt-1.15.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7dc0713bf81287a00516ef43137273b23ee414fe41a3c14be10dd95ed98a2df9"},
+    {file = "wrapt-1.15.0-cp39-cp39-win32.whl", hash = "sha256:46ed616d5fb42f98630ed70c3529541408166c22cdfd4540b88d5f21006b0eff"},
+    {file = "wrapt-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:eef4d64c650f33347c1f9266fa5ae001440b232ad9b98f1f43dfe7a79435c0a6"},
+    {file = "wrapt-1.15.0-py3-none-any.whl", hash = "sha256:64b1df0f83706b4ef4cfb4fb0e4c2669100fd7ecacfb59e091fad300d4e04640"},
+    {file = "wrapt-1.15.0.tar.gz", hash = "sha256:d06730c6aed78cee4126234cf2d071e01b44b915e725a6cb439a879ec9754a3a"},
 ]
 yarl = [
     {file = "yarl-1.8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bb81f753c815f6b8e2ddd2eef3c855cf7da193b82396ac013c661aaa6cc6b0a5"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ oauth2-client = "^1.3.0"
 Pillow = "*"
 python-dotenv = "^1.0.0"
 packaging = "^23.0"
+wrapt = "^1.15.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fixieai"
-version = "0.2.15"
+version = "0.2.16"
 description = "SDK for the Fixie.ai platform. See: https://fixie.ai"
 authors = ["Fixie.ai Team <hello@fixie.ai>"]
 packages = [


### PR DESCRIPTION
This allows agents to use Fixie as an OpenAI proxy in the context of agent requests.

When an agent (that does not set either `OPENAI_API_{BASE,KEY}` in its `.env` file) is loaded, we:
1. Set `OPENAI_API_BASE` to point to the Fixie OpenAI proxy
2. Set `OPENAI_API_KEY` to a fake key value
3. Patch OpenAI's `ApiRequestor` object to replace the fake key with the auth token from the current request (for requests that would be sent to Fixie).

During request handling, middleware puts the auth token in a `ContextVar` that the patched `ApiRequestor` will read.