### PR TITLE
Fix `fixie deploy`/`fixie serve --venv` when using relative paths

### DIFF
--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -353,7 +353,7 @@ def _validate_agent_loads_or_exit(
 ):
     """Validates that an agent can successfully load and exits the current process if it can't."""
     loader_process = subprocess.run(
-        [python_exe, "-m", "fixieai.cli.agent.loader"],
+        [os.path.abspath(python_exe), "-m", "fixieai.cli.agent.loader"],
         env=agent_env,
         cwd=agent_dir or None,
     )
@@ -447,7 +447,7 @@ def serve(ctx, path, host, port, use_tunnel, reload, use_venv):
         agent_env[FIXIE_REFRESH_ON_STARTUP] = "true"
         subprocess.run(
             [
-                python_exe,
+                os.path.abspath(python_exe),
                 "-m",
                 "uvicorn",
                 "fixieai.cli.agent.loader:uvicorn_app_factory",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fixieai"
-version = "0.2.16"
+version = "0.2.17"
 description = "SDK for the Fixie.ai platform. See: https://fixie.ai"
 authors = ["Fixie.ai Team <hello@fixie.ai>"]
 packages = [


### PR DESCRIPTION
`subprocess.run` changes the directory before running the executable, so we need to make sure the executable path is made absolute.