### PR TITLE
Fix incorrect type for uvicorn port argument

### DIFF
--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -473,7 +473,8 @@ if __name__ == "__main__":
     import uvicorn
 
     from fixieai.cli.agent import loader
-    uvicorn.run(loader.uvicorn_app_factory(), host="0.0.0.0", port=os.getenv("PORT", "8080"))
+    port = int(os.getenv("PORT", 8080))
+    uvicorn.run(loader.uvicorn_app_factory(), host="0.0.0.0", port=port)
 """
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fixieai"
-version = "0.2.20"
+version = "0.2.21"
 description = "SDK for the Fixie.ai platform. See: https://fixie.ai"
 authors = ["Fixie.ai Team <hello@fixie.ai>"]
 packages = [


### PR DESCRIPTION
The CLI incorrectly passed the port to uvicorn as a string, rather than an integer, causing log spew on startup.