### PR TITLE
Support error message propagation from agents

### DIFF
--- a/fixieai/agents/agent_base.py
+++ b/fixieai/agents/agent_base.py
@@ -4,7 +4,6 @@ import abc
 import dataclasses
 import functools
 import json
-import logging
 import os
 import re
 import warnings
@@ -16,23 +15,19 @@ import jwt
 import starlette.responses
 import uvicorn
 import yaml
-from pydantic import dataclasses as pydantic_dataclasses
 
 from fixieai import constants
 from fixieai.agents import agent_func
 from fixieai.agents import api
+from fixieai.agents import exceptions
 from fixieai.agents import metadata as agent_metadata
 from fixieai.agents import oauth
+from fixieai.agents import token
 
 # Regex that controls what Func names are allowed.
 ACCEPTED_FUNC_NAMES = re.compile(r"^\w+$")
 
-# The JWT claim containing the agent ID
-_AGENT_ID_JWT_CLAIM = "aid"
-
 _RESPONSE_CHUNK_SIZE = 1024
-
-logger = logging.getLogger(__file__)
 
 
 class AgentBase(abc.ABC):
@@ -77,6 +72,9 @@ class AgentBase(abc.ABC):
         """Returns a fastapi.FastAPI application that serves the agent."""
         fast_api = fastapi.FastAPI()
         fast_api.include_router(self.api_router())
+        fast_api.add_exception_handler(
+            exceptions.AgentException, exceptions.AgentException.fastapi_handler
+        )
 
         return fast_api
 
@@ -144,7 +142,7 @@ class AgentBase(abc.ABC):
         ),
     ) -> fastapi.Response:
         """Returns the agent's metadata in YAML format."""
-        token_claims = VerifiedTokenClaims.from_token(
+        token_claims = token.VerifiedTokenClaims.from_token(
             credentials.credentials, self._jwks_client, self._allowed_agent_id
         )
         if token_claims is None:
@@ -163,26 +161,6 @@ class AgentBase(abc.ABC):
             media_type="application/yaml",
         )
 
-    def validate_token_and_update_query_access_token(
-        self,
-        query: api.AgentQuery,
-        credentials: fastapi.security.HTTPAuthorizationCredentials,
-    ):
-        token_claims = VerifiedTokenClaims.from_token(
-            credentials.credentials, self._jwks_client, self._allowed_agent_id
-        )
-        if token_claims is None:
-            raise fastapi.HTTPException(status_code=403, detail="Invalid token")
-        elif (
-            query.access_token is not None
-            and query.access_token != credentials.credentials
-        ):
-            raise fastapi.HTTPException(status_code=403, detail="Mismatched tokens")
-        else:
-            query.access_token = credentials.credentials
-
-        return token_claims
-
     def _serve_func(
         self,
         func_name: str,
@@ -194,60 +172,28 @@ class AgentBase(abc.ABC):
         """Verifies the request is a valid request from Fixie, and dispatches it to
         the appropriate function.
         """
-        token_claims = self.validate_token_and_update_query_access_token(
-            query, credentials
+        token_claims = token.VerifiedTokenClaims.from_token(
+            credentials.credentials, self._jwks_client, self._allowed_agent_id
         )
+        if token_claims is None:
+            raise fastapi.HTTPException(status_code=403, detail="Invalid token")
 
         try:
             pyfunc = self._funcs[func_name]
         except KeyError:
-            raise fastapi.HTTPException(
-                status_code=404, detail=f"Func[{func_name}] doesn't exist"
+            raise exceptions.AgentException(
+                response_message=f"I'm sorry, Func[{func_name}] is not defined.",
+                error_code="ERR_FUNC_NOT_DEFINED",
+                error_message="The function was not defined.",
+                http_status_code=404,
+                func_name=func_name,
+                available_funcs=list(self._funcs.keys()),
             )
 
-        output = pyfunc(query, token_claims.agent_id)
+        output = pyfunc(query, token_claims)
 
         # Streaming not allowed for funcs (yet).
         return next(iter(output))
-
-
-@pydantic_dataclasses.dataclass
-class VerifiedTokenClaims:
-    """Verified claims from an agent token."""
-
-    agent_id: str
-
-    @staticmethod
-    def from_token(
-        token: str,
-        jwks_client: jwt.PyJWKClient,
-        expected_agent_id: Optional[str],
-    ) -> Optional[VerifiedTokenClaims]:
-        try:
-            public_key = jwks_client.get_signing_key_from_jwt(token)
-            claims = jwt.decode(
-                token,
-                public_key.key,
-                algorithms=["EdDSA"],
-                audience=constants.FIXIE_AGENT_API_AUDIENCES,
-            )
-        except jwt.DecodeError:
-            return None
-
-        token_agent_id = claims.get(_AGENT_ID_JWT_CLAIM)
-        if not isinstance(token_agent_id, str):
-            # Agent id claim is required
-            logger.warning("Rejecting valid JWT without any agent ID claim")
-            return None
-
-        if expected_agent_id is not None and token_agent_id != expected_agent_id:
-            # The agent ID in the token did not match the allowed value.
-            logger.warning(
-                f"Rejecting valid JWT because agent ID in token ({token_agent_id!r}) did not match {expected_agent_id!r}"
-            )
-            return None
-
-        return VerifiedTokenClaims(agent_id=token_agent_id)
 
 
 def _oauth(query: api.Message, oauth_handler: oauth.OAuthHandler) -> str:

--- a/fixieai/agents/agent_func.py
+++ b/fixieai/agents/agent_func.py
@@ -16,11 +16,13 @@ from typing import (
 )
 
 from fixieai.agents import api
+from fixieai.agents import exceptions
 from fixieai.agents import oauth
+from fixieai.agents import token
 from fixieai.agents import user_storage
 
-# An ArgumentMapper converts a query+agent ID into a supported func argument (e.g. "query" or "user_storage")
-ArgumentMapper = Callable[[api.AgentQuery, str], Any]
+# An ArgumentMapper converts a query + token claims into a supported func argument (e.g. "query" or "user_storage")
+ArgumentMapper = Callable[[api.AgentQuery, token.VerifiedTokenClaims], Any]
 
 # BoundArgumentMapper is an ArgumentMapper that has been bound to a named parameter.
 BoundArgumentMapper = Tuple[str, ArgumentMapper]
@@ -51,14 +53,26 @@ class AgentFunc:
         self._allow_multiple_responses = allow_multiple_responses
 
     def __call__(
-        self, agent_query: api.AgentQuery, agent_id: str
+        self, agent_query: api.AgentQuery, claims: token.VerifiedTokenClaims
     ) -> Iterable[api.AgentResponse]:
         kwargs = {}
         for name, mapper in self._argument_mappers:
-            kwargs[name] = mapper(agent_query, agent_id)
+            kwargs[name] = mapper(agent_query, claims)
 
-        result = self._impl(**kwargs)
-        return _adapt_func_result(result, self._allow_multiple_responses)
+        with exceptions.AgentException.exception_remapper():
+            result = self._impl(**kwargs)
+
+        def _gen() -> Iterable[api.AgentResponse]:
+            # Within a generator we need to catch exceptions and convert them to responses.
+            try:
+                with exceptions.AgentException.exception_remapper():
+                    yield from _adapt_func_result(
+                        result, self._allow_multiple_responses
+                    )
+            except exceptions.AgentException as e:
+                yield e.to_response()
+
+        return _gen()
 
     @classmethod
     def create(
@@ -109,9 +123,9 @@ class AgentFunc:
 
         # Try to bind a query/message mapper.
         typed_message_mappers = {
-            api.AgentQuery: lambda query, agent_id: query,
-            api.Message: lambda query, agent_id: query.message,
-            str: lambda query, agent_id: query.message.text,
+            api.AgentQuery: lambda query, claims: query,
+            api.Message: lambda query, claims: query.message,
+            str: lambda query, claims: query.message.text,
         }
         bound_message_mapper = _bind_argument_mapper(
             func,
@@ -124,9 +138,7 @@ class AgentFunc:
         )
 
         # Try to bind a UserStorage mapper.
-        user_storage_mapper = lambda query, agent_id: user_storage.UserStorage(
-            query, agent_id
-        )
+        user_storage_mapper = lambda query, claims: user_storage.UserStorage(claims)
         bound_user_storage_mapper = _bind_argument_mapper(
             func,
             unbound_parameter_names=unbound_parameter_names,
@@ -137,8 +149,8 @@ class AgentFunc:
         )
 
         # Try to bind an OAuthHandler mapper.
-        oauth_mapper = lambda query, agent_id: oauth_params and oauth.OAuthHandler(
-            oauth_params, query, agent_id
+        oauth_mapper = lambda query, claims: oauth_params and oauth.OAuthHandler(
+            oauth_params, claims
         )
         bound_oauth_mapper = _bind_argument_mapper(
             func,

--- a/fixieai/agents/agent_func.py
+++ b/fixieai/agents/agent_func.py
@@ -55,11 +55,11 @@ class AgentFunc:
     def __call__(
         self, agent_query: api.AgentQuery, claims: token.VerifiedTokenClaims
     ) -> Iterable[api.AgentResponse]:
-        kwargs = {}
-        for name, mapper in self._argument_mappers:
-            kwargs[name] = mapper(agent_query, claims)
-
         with exceptions.AgentException.exception_remapper():
+            kwargs = {}
+            for name, mapper in self._argument_mappers:
+                kwargs[name] = mapper(agent_query, claims)
+
             result = self._impl(**kwargs)
 
         def _gen() -> Iterable[api.AgentResponse]:

--- a/fixieai/agents/agent_func_test.py
+++ b/fixieai/agents/agent_func_test.py
@@ -6,6 +6,7 @@ import fixieai
 from fixieai.agents import agent_func
 from fixieai.agents import api
 from fixieai.agents import oauth
+from fixieai.agents import token
 
 
 @pytest.fixture
@@ -32,7 +33,8 @@ def test_create_from_python_type_coercion(oauth_params):
             )
             query_text = "Test query"
             result = normalized(
-                api.AgentQuery(api.Message(text=query_text)), "test-agent-id"
+                api.AgentQuery(api.Message(text=query_text)),
+                token.VerifiedTokenClaims("test-agent-id", False, "FAKE_TOKEN"),
             )
 
             expected_results = (

--- a/fixieai/agents/api.py
+++ b/fixieai/agents/api.py
@@ -70,11 +70,29 @@ class AgentQuery:
 
 
 @pydantic_dataclasses.dataclass
+class AgentError:
+    """An error that occurred in the process of generating a response."""
+
+    # A code representing the error.
+    code: str
+
+    # A message describing the error that will be displayed to the user.
+    message: str
+
+    # Additional debugging context from the error.
+    details: Optional[Dict]
+
+
+@pydantic_dataclasses.dataclass
 class AgentResponse:
     """A response message from an Agent."""
 
     # The text of the response message.
     message: Message
+
+    # Error details, if an error occurred generating the response. Note that `message` should still be included,
+    # but may indicate that an error occurred that prevented the agent from fully handling the request.
+    error: Optional[AgentError] = None
 
 
 AgentResponseGenerator = Generator[AgentResponse, None, None]

--- a/fixieai/agents/code_shot_test.py
+++ b/fixieai/agents/code_shot_test.py
@@ -8,8 +8,8 @@ from fastapi import testclient
 
 import fixieai
 from fixieai import agents
-from fixieai.agents import agent_base
 from fixieai.agents import code_shot
+from fixieai.agents import token
 
 agent_id = "dummy"
 BASE_PROMPT = "I am a simple dummy agent."
@@ -34,9 +34,11 @@ CORPORA = [
 @pytest.fixture(autouse=True)
 def mock_token_verifier(mocker):
     return mocker.patch.object(
-        agent_base.VerifiedTokenClaims,
+        token.VerifiedTokenClaims,
         "from_token",
-        return_value=agent_base.VerifiedTokenClaims(agent_id="fake agent id"),
+        return_value=token.VerifiedTokenClaims(
+            agent_id="fake agent id", is_anonymous=False, token="fake token"
+        ),
     )
 
 

--- a/fixieai/agents/exceptions.py
+++ b/fixieai/agents/exceptions.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import traceback
+
+import fastapi
+from fastapi.responses import JSONResponse
+
+from fixieai.agents import api
+
+UNHANDLED_EXCEPTION_RESPONSE_TEXT = (
+    "I'm sorry, an error occurred while processing your request."
+)
+
+
+class AgentException(Exception):
+    """An exception raised by an Agent."""
+
+    def __init__(
+        self,
+        response_message: str,
+        error_code: str,
+        error_message: str,
+        http_status_code: int = 500,
+        **details,
+    ):
+        super().__init__(error_message)
+        self._response_message = response_message
+        self._http_status_code = http_status_code
+        self._error_code = error_code
+        self._error_message = error_message
+        self._details = details
+
+    def to_response(self) -> api.AgentResponse:
+        """Converts the AgentException into an AgentResponse."""
+
+        # Add exception details to the error details.
+        error = api.AgentError(
+            code=self._error_code,
+            message=self._error_message,
+            details={
+                "traceback": traceback.format_exception(
+                    type(self), self, self.__traceback__
+                ),
+                **self._details,
+            },
+        )
+
+        return api.AgentResponse(
+            api.Message(self._response_message),
+            error=error,
+        )
+
+    @classmethod
+    def fastapi_handler(cls, request: fastapi.Request, exc: AgentException):
+        """A FastAPI exception handler for AgentExceptions."""
+        return JSONResponse(
+            dataclasses.asdict(exc.to_response()),
+            status_code=exc._http_status_code,
+        )
+
+    @staticmethod
+    @contextlib.contextmanager
+    def exception_remapper():
+        """Remaps unhandled exceptions into AgentExceptions."""
+        try:
+            yield
+        except AgentException:
+            raise
+        except Exception as exc:
+            raise AgentException(
+                response_message=UNHANDLED_EXCEPTION_RESPONSE_TEXT,
+                error_code="ERR_AGENT_UNHANDLED_EXCEPTION",
+                error_message="An unhandled exception occurred while processing the request.",
+                http_status_code=500,
+            ) from exc

--- a/fixieai/agents/oauth.py
+++ b/fixieai/agents/oauth.py
@@ -10,7 +10,7 @@ import dataclasses_json
 import requests
 
 from fixieai import constants
-from fixieai.agents import api
+from fixieai.agents import token
 from fixieai.agents import user_storage
 
 
@@ -70,12 +70,11 @@ class OAuthHandler:
     def __init__(
         self,
         oauth_params: OAuthParams,
-        query: api.AgentQuery,
-        agent_id: str,
+        token_claims: token.VerifiedTokenClaims,
     ):
-        self._storage = user_storage.UserStorage(query, agent_id)
+        self._storage = user_storage.UserStorage(token_claims)
         self._oauth_params = oauth_params
-        self._agent_id = agent_id
+        self._agent_id = token_claims.agent_id
 
     def get_authorization_url(self) -> str:
         """Returns a URL to launch the authorization flow."""

--- a/fixieai/agents/token.py
+++ b/fixieai/agents/token.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import jwt
+from pydantic import dataclasses as pydantic_dataclasses
+
+from fixieai import constants
+
+# The JWT claim containing the agent ID
+_AGENT_ID_JWT_CLAIM = "aid"
+_USER_ID_JWT_CLAIM = "sub"
+
+logger = logging.getLogger(__file__)
+
+
+@pydantic_dataclasses.dataclass
+class VerifiedTokenClaims:
+    """Verified claims from an agent token."""
+
+    # The agent_id for which the request is intended.
+    agent_id: str
+
+    # Indicates whether the request is on behalf of a user or anonymous.
+    is_anonymous: bool
+
+    # The verified token.
+    token: str
+
+    @staticmethod
+    def from_token(
+        token: str,
+        jwks_client: jwt.PyJWKClient,
+        expected_agent_id: Optional[str],
+    ) -> Optional[VerifiedTokenClaims]:
+        try:
+            public_key = jwks_client.get_signing_key_from_jwt(token)
+            claims = jwt.decode(
+                token,
+                public_key.key,
+                algorithms=["EdDSA"],
+                audience=constants.FIXIE_AGENT_API_AUDIENCES,
+            )
+        except jwt.DecodeError:
+            return None
+
+        token_agent_id = claims.get(_AGENT_ID_JWT_CLAIM)
+        if not isinstance(token_agent_id, str):
+            # Agent id claim is required
+            logger.warning("Rejecting valid JWT without any agent ID claim")
+            return None
+
+        if expected_agent_id is not None and token_agent_id != expected_agent_id:
+            # The agent ID in the token did not match the allowed value.
+            logger.warning(
+                f"Rejecting valid JWT because agent ID in token ({token_agent_id!r}) did not match {expected_agent_id!r}"
+            )
+            return None
+
+        return VerifiedTokenClaims(
+            agent_id=token_agent_id,
+            is_anonymous=claims.get(_USER_ID_JWT_CLAIM) is None,
+            token=token,
+        )

--- a/fixieai/agents/user_storage.py
+++ b/fixieai/agents/user_storage.py
@@ -1,13 +1,12 @@
 import base64
 import json
-from typing import TYPE_CHECKING, Dict, List, MutableMapping, Union
+from typing import Dict, List, MutableMapping, Union
 
 import requests
 
 from fixieai import constants
 from fixieai.agents import exceptions
 from fixieai.agents import token
-
 
 UserStoragePrimitives = Union[bool, int, float, str, bytes, None]
 UserStorageType = Union[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fixieai"
-version = "0.2.21"
+version = "0.2.22"
 description = "SDK for the Fixie.ai platform. See: https://fixie.ai"
 authors = ["Fixie.ai Team <hello@fixie.ai>"]
 packages = [


### PR DESCRIPTION
This adds support for propagating `AgentError`s back to Fixie.

It defines an `AgentException` type that is automatically converted into an `AgentResponse` with a FastAPI exception handler, and the func invoker remaps unhandled exceptions to an `AgentException` to handle everything else.

Additionally, `UserStorage.__init__` will now raise an `AgentException` if it is instantiated on behalf of an anonymous user -- that type is refactored to take `VerifiedTokenClaims` to support this.