### PR TITLE
Add revisions CLI commands

### DIFF
--- a/fixieai/client/agent.py
+++ b/fixieai/client/agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from gql import gql
@@ -271,6 +272,9 @@ class Agent:
         if query_url is not None:
             variable_values["queryUrl"] = query_url
         if func_url is not None:
+            warnings.warn(
+                "Setting func_url via create_agent is deprecated, use FixieClient.create_agent_revision instead."
+            )
             variable_values["funcUrl"] = func_url
         if more_info_url is not None:
             variable_values["moreInfoUrl"] = more_info_url
@@ -338,6 +342,9 @@ class Agent:
         if query_url is not None:
             variable_values["queryUrl"] = query_url
         if func_url is not None:
+            warnings.warn(
+                "Setting func_url via update_agent is deprecated, use FixieClient.create_agent_revision instead."
+            )
             variable_values["funcUrl"] = func_url
         if more_info_url is not None:
             variable_values["moreInfoUrl"] = more_info_url

--- a/fixieai/client/utils.py
+++ b/fixieai/client/utils.py
@@ -1,0 +1,44 @@
+import contextlib
+import functools
+from typing import BinaryIO, Optional
+
+from requests_toolbelt.multipart.encoder import MultipartEncoder  # type: ignore
+
+
+@contextlib.contextmanager
+def patched_gql_file_uploader(
+    file_like: Optional[BinaryIO], name: str, content_type: str
+):
+    """Applies a temporary patch to allow setting name and Content-Type on uploads via `gql`.
+
+    Future versions of `gql` will support setting Content-Type, but even with that support
+    `gql` requires that the stream being uploaded is named and FixieClient does not. So this
+    patches the underlying multipart encoder to assign the name and Content-Type to the specified
+    stream.
+    """
+
+    if file_like is None:
+        yield
+        return
+
+    @functools.wraps(MultipartEncoder.__init__)
+    def _patched_init(self, fields, *args, **kwargs):
+        patched_fields = {
+            k: (
+                (
+                    name,
+                    file_like,
+                    content_type,
+                )
+                if len(v) == 2 and v[1] == file_like
+                else v
+            )
+            for k, v in fields.items()
+        }
+        _patched_init.__wrapped__(self, patched_fields, *args, **kwargs)  # type: ignore
+
+    try:
+        MultipartEncoder.__init__ = _patched_init
+        yield
+    finally:
+        MultipartEncoder.__init__ = _patched_init.__wrapped__  # type: ignore


### PR DESCRIPTION
This adds revisions-related commands to the CLI:
- `fixie agent revisions list` lists all revisions associated with an agent
- `fixie agent revisions set-current` sets the current revision
- `fixie agent revisions delete` deletes a revision

It also adds revisions-related methods to `FixieClient`. (A separate PR will migrate `fixie agent serve` and `fixie agent deploy` to use the revisions API as well.)