### PR TITLE
Change `fixie serve` and `fixie deploy` to use revisions API

### DIFF
--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -6,11 +6,13 @@ import pathlib
 import random
 import re
 import shlex
+import socket
 import subprocess
 import sys
 import tarfile
 import tempfile
 import threading
+import time
 import urllib.request
 import venv
 from contextlib import contextmanager
@@ -20,6 +22,7 @@ import click
 import rich.console as rich_console
 import rich.table
 import validators
+import watchfiles
 from gql import gql
 
 import fixieai.client
@@ -55,6 +58,15 @@ def _slugify(s: str) -> str:
     s = re.sub(r"[\s_-]+", "-", s)
     s = s.strip("-")
     return s
+
+
+def _cli_revision_metadata(command: str) -> dict:
+    """Returns common agent revision metadata for CLI-created revisions."""
+    return {
+        "fixie.ai/client": "python-cli",
+        "fixie.ai/python-cli/command": command,
+        "fixie.ai/python-cli/version": fixieai.__version__,
+    }
 
 
 def _update_agent_requirements(
@@ -239,10 +251,6 @@ def show_agent(ctx, agent_id: str):
     if agent.more_info_url:
         click.echo(f"More info URL: {agent.more_info_url}")
     click.echo(f"Published: {agent.published}")
-    if agent.func_url:
-        click.echo(f"Func URL: {agent.func_url}")
-    if agent.query_url:
-        click.echo(f"Query URL: {agent.query_url}")
     click.echo(f"Created: {agent.created}")
     click.echo(f"Modified: {agent.modified}")
     if agent.queries:
@@ -287,7 +295,6 @@ def _ensure_agent_updated(
             name=config.name,
             description=config.description,
             more_info_url=config.more_info_url,
-            func_url=config.deployment_url,
             published=config.public or False,
         )
     else:
@@ -296,7 +303,6 @@ def _ensure_agent_updated(
             name=config.name,
             description=config.description,
             more_info_url=config.more_info_url,
-            func_url=config.deployment_url,
             published=config.public or False,
         )
 
@@ -364,6 +370,127 @@ def _validate_agent_loads_or_exit(
         sys.exit(loader_process.returncode)
 
 
+@contextlib.contextmanager
+def _temporary_revision_replacer(
+    console: rich.console.Console, client: fixieai.FixieClient, agent_handle: str
+):
+    """Yields a function that can be used to temporarily replace an agent's current revision."""
+
+    # Get the preexisting revision so that we can restore it when we're done.
+    existing_revision_id = client.get_current_agent_revision(agent_handle)
+    current_temporary_revision: Optional[str] = None
+
+    if existing_revision_id is not None:
+        console.print(
+            f"[yellow]This temporarily replaces existing revision {existing_revision_id}.[/yellow]"
+        )
+
+    def replace_revision(external_url: str):
+        nonlocal current_temporary_revision
+
+        # Create a new temporary revision.
+        revision_to_delete = current_temporary_revision
+        current_temporary_revision = client.create_agent_revision(
+            handle=agent_handle,
+            make_current=True,
+            metadata=_cli_revision_metadata("serve"),
+            external_url=external_url,
+        )
+
+        # Delete the previous temporary revision.
+        if revision_to_delete:
+            client.delete_agent_revision(agent_handle, revision_to_delete)
+
+        console.print(
+            f"[green]Now serving temporary revision {current_temporary_revision}.[/green]"
+        )
+
+    try:
+        yield replace_revision
+    finally:
+        if existing_revision_id:
+            client.set_current_agent_revision(agent_handle, existing_revision_id)
+            console.print(
+                f"[yellow]Restored existing revision {existing_revision_id}.[/yellow]"
+            )
+
+        if current_temporary_revision:
+            client.delete_agent_revision(agent_handle, current_temporary_revision)
+
+
+@contextlib.contextmanager
+def _server_process(
+    console: rich_console.Console,
+    on_exit_event: threading.Event,
+    python_exe: str,
+    host: str,
+    port: int,
+    agent_env: Dict[str, str],
+    agent_dir: str,
+    startup_timeout_seconds: float,
+):
+    """Yields a Popen object with a running and ready server process."""
+
+    with subprocess.Popen(
+        [
+            os.path.abspath(python_exe),
+            "-m",
+            "uvicorn",
+            "fixieai.cli.agent.loader:uvicorn_app_factory",
+            "--host",
+            host,
+            "--port",
+            str(port),
+            "--factory",
+        ],
+        env=agent_env,
+        cwd=agent_dir or None,
+    ) as popen:
+
+        def _wait_for_exit():
+            popen.wait()
+            on_exit_event.set()
+
+        waiter_thread = threading.Thread(target=_wait_for_exit, daemon=True)
+        waiter_thread.start()
+
+        try:
+            # Wait for the server to start up by polling the port.
+            deadline = time.monotonic() + startup_timeout_seconds
+            while time.monotonic() < deadline and popen.poll() is None:
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                    try:
+                        s.connect(("127.0.0.1" if host == "0.0.0.0" else host, port))
+                        break
+                    except ConnectionRefusedError:
+                        time.sleep(0.1)
+
+            if time.monotonic() >= deadline or popen.poll() is not None:
+                console.print("Server process failed to start.", style="red")
+                raise click.Abort()
+
+            yield popen
+        finally:
+            popen.terminate()
+            waiter_thread.join()
+
+
+def _wait_for_agent_changes_or_event(
+    agent_dir: str, event: threading.Event
+) -> Optional[str]:
+    """Waits for any changes in the specified directory or the event to be set."""
+
+    for changes in watchfiles.watch(
+        agent_dir,
+        watch_filter=lambda change, path: path.endswith(".py"),
+        stop_event=event,
+    ):
+        for change, path in changes:
+            return path
+
+    return None
+
+
 @agent.command(
     "serve", help="Serve the current agent locally via a publicly-accessible URL."
 )
@@ -405,65 +532,90 @@ def serve(ctx, path, host, port, use_tunnel, reload, use_venv):
             python_exe, agent_env = _configure_venv(console, agent_dir)
         else:
             python_exe, agent_env = sys.executable, os.environ.copy()
-
         agent_env[FIXIE_ALLOWED_AGENT_ID] = agent_id
-
-        # Validate that the agent loads before setting up the server.
-        _validate_agent_loads_or_exit(
-            console, agent_dir, config.handle, python_exe, agent_env
-        )
 
         if use_tunnel:
             # Start up a tunnel via localhost.run.
             console.print(f"Opening tunnel to {host}:{port} via localhost.run.")
-            console.print(
-                f"[yellow]This replaces any existing deployment, run [bold]fixie deploy[/bold] to redeploy to prod.[/yellow]"
-            )
             deployment_urls_iter = iter(stack.enter_context(tunnel.Tunnel(port)))
-            config.deployment_url = next(deployment_urls_iter)
-
-            agent_api = _ensure_agent_updated(client, agent_id, config)
-
-            def _watch_tunnel():
-                while True:
-                    url = next(deployment_urls_iter, None)
-                    if url is None:
-                        break
-                    agent_api.update_agent(func_url=url)
-                    console.print(
-                        f"[yellow]Tunnel URL was updated, now serving via {url}[/yellow]"
-                    )
-
-            threading.Thread(target=_watch_tunnel, daemon=True).start()
+        elif config.deployment_url:
+            deployment_urls_iter = iter([config.deployment_url])
         else:
-            agent_api = _ensure_agent_updated(client, agent_id, config)
+            console.print(
+                f"[red]You must specify a deployment_url in agent.yaml or use --tunnel.[/red]"
+            )
+            raise click.Abort()
 
-        console.print(
-            f"🦊 Agent [green]{agent_api.agent_id}[/] running locally on {host}:{port}, served via {agent_api.func_url}"
-        )
+        agent_api = _ensure_agent_updated(client, agent_id, config)
         console.print(
             f"You can access your agent via [cyan]{client.get_agent_page_url(agent_api.agent_id)}[/]"
             f" or `[green]fixie console --agent {agent_api.agent_id}[/]`."
         )
 
-        # Trigger an agent refresh each time it reloads.
-        agent_env[FIXIE_REFRESH_ON_STARTUP] = "true"
-        subprocess.run(
-            [
-                os.path.abspath(python_exe),
-                "-m",
-                "uvicorn",
-                "fixieai.cli.agent.loader:uvicorn_app_factory",
-                "--host",
+        replace_revision = stack.enter_context(
+            _temporary_revision_replacer(console, client, config.handle)
+        )
+
+        # An Event that indicates that either the subprocess exited or the tunnel URL has been rotated.
+        requires_action = threading.Event()
+        current_url = next(deployment_urls_iter)
+
+        def _watch_tunnel():
+            """Watches the tunnel for URL rotations."""
+            nonlocal current_url
+
+            while True:
+                try:
+                    current_url = next(deployment_urls_iter)
+                except StopIteration:
+                    return
+                finally:
+                    requires_action.set()
+
+        threading.Thread(target=_watch_tunnel, daemon=True).start()
+
+        while True:
+            requires_action.clear()
+
+            with _server_process(
+                console,
+                requires_action,
+                python_exe,
                 host,
-                "--port",
-                str(port),
-                "--factory",
-            ]
-            + (["--reload"] if reload else []),
-            env=agent_env,
-            cwd=agent_dir or None,
-        ).check_returncode()
+                port,
+                agent_env,
+                agent_dir,
+                startup_timeout_seconds=10.0,
+            ) as popen:
+
+                # The server has started up, so we can replace the revision.
+                replace_revision(current_url)
+
+                while True:
+                    if reload:
+                        changed_file = _wait_for_agent_changes_or_event(
+                            agent_dir, requires_action
+                        )
+                        if changed_file is not None:
+                            console.print(
+                                f"[yellow]{changed_file} was changed. Restarting server.[/yellow]"
+                            )
+                            break
+                        else:
+                            assert requires_action.is_set()
+
+                    requires_action.wait()
+                    requires_action.clear()
+
+                    if popen.poll() is not None:
+                        console.print(
+                            "The server process stopped, exiting.",
+                            style="red" if popen.returncode != 0 else None,
+                        )
+                        raise click.exceptions.Exit(popen.returncode)
+                    else:
+                        # The tunnel URL changed.
+                        replace_revision(current_url)
 
 
 _DEPLOYMENT_BOOTSTRAP_SOURCE = """
@@ -525,12 +677,43 @@ def _add_text_file_to_tarfile(path: str, text: str, tarball: tarfile.TarFile):
     tarball.addfile(tarinfo, io.BytesIO(file_bytes))
 
 
+@contextlib.contextmanager
+def _agent_code_package(agent_dir: str, agent_id: str, console: rich_console.Console):
+    """Yields a file-like code package that can be deployed to Fixie."""
+
+    with tempfile.TemporaryFile() as tarball_file:
+        with tarfile.open(fileobj=tarball_file, mode="w:gz") as tarball:
+            tarball.add(
+                agent_dir,
+                arcname="agent",
+                filter=functools.partial(_tarinfo_filter, console, agent_dir, "agent/"),
+            )
+
+            # Add the bootstrapping code and environment variables
+            _add_text_file_to_tarfile("main.py", _DEPLOYMENT_BOOTSTRAP_SOURCE, tarball)
+            _add_text_file_to_tarfile(
+                ".env",
+                "\n".join(
+                    f"{key}={value}"
+                    for key, value in {
+                        FIXIE_ALLOWED_AGENT_ID: agent_id,
+                        "FIXIE_API_URL": constants.FIXIE_API_URL,
+                    }.items()
+                ),
+                tarball,
+            )
+
+        tarball_file.seek(0)
+        yield tarball_file
+
+
 @agent.command("deploy", help="Deploy the current agent.")
 @click.argument("path", callback=_validate_agent_path, required=False)
 @click.option(
     "--metadata-only",
     is_flag=True,
-    help="Only publish metadata and refresh, do not redeploy.",
+    default=None,
+    help="(No longer supported.)",
 )
 @click.option("--public", is_flag=True, help="Make the agent public.", default=None)
 @click.option(
@@ -538,11 +721,37 @@ def _add_text_file_to_tarfile(path: str, text: str, tarball: tarfile.TarFile):
     "validate",
     is_flag=True,
     default=True,
-    help="(default enabled) Validate that the agent loads in a local venv before deploying",
+    help="(default enabled) Validate that the agent loads in a local venv before deploying.",
+)
+@click.option(
+    "--current/--not-current",
+    "make_current",
+    is_flag=True,
+    default=True,
+    help="(default enabled) Change the current revision to the deployed revision.",
+)
+@click.option(
+    "--metadata",
+    nargs=2,
+    type=str,
+    help="Additional metadata to associate with the revision.",
+    multiple=True,
+)
+@click.option(
+    "--reindex/--no-reindex",
+    "reindex",
+    is_flag=True,
+    default=False,
+    help="Force any corpora to be reindexed.",
 )
 @click.pass_context
-def deploy(ctx, path, metadata_only, public, validate):
+def deploy(ctx, path, metadata_only, public, validate, make_current, metadata, reindex):
     console = rich_console.Console(soft_wrap=True)
+    if metadata_only is not None:
+        console.print(
+            "[yellow]Warning:[/] The [blue]--metadata-only[/] option is no longer supported."
+        )
+
     config = agent_config.load_config(path)
     if config.public is not None:
         console.print(
@@ -567,58 +776,55 @@ def deploy(ctx, path, metadata_only, public, validate):
             console, agent_dir, config.handle, python_exe, agent_env
         )
 
-    agent_api = _ensure_agent_updated(client, agent_id, config)
+    _ = _ensure_agent_updated(client, agent_id, config)
 
-    if config.deployment_url is None and not metadata_only:
-        # Deploy the agent to fixie with some bootstrapping code.
-        with tempfile.TemporaryFile() as tarball_file:
-            with tarfile.open(fileobj=tarball_file, mode="w:gz") as tarball:
-                tarball.add(
-                    agent_dir,
-                    arcname="agent",
-                    filter=functools.partial(
-                        _tarinfo_filter, console, agent_dir, "agent/"
-                    ),
-                )
+    metadata_dict = {**dict(metadata or []), **_cli_revision_metadata("deploy")}
 
-                # Add the bootstrapping code and environment variables
-                _add_text_file_to_tarfile(
-                    "main.py", _DEPLOYMENT_BOOTSTRAP_SOURCE, tarball
-                )
-                _add_text_file_to_tarfile(
-                    ".env",
-                    "\n".join(
-                        f"{key}={value}"
-                        for key, value in {
-                            FIXIE_ALLOWED_AGENT_ID: agent_id,
-                            "FIXIE_API_URL": constants.FIXIE_API_URL,
-                        }.items()
-                    ),
-                    tarball,
-                )
+    if config.deployment_url is None:
+        # Deploy the code to Fixie.
+        with _agent_code_package(
+            agent_dir, agent_id, console
+        ) as tarball_file, _spinner(console, "Deploying..."):
+            revision_id = client.create_agent_revision(
+                config.handle,
+                make_current=make_current,
+                metadata=metadata_dict,
+                python_gzip_tarfile=tarball_file,
+                reindex_corpora=reindex,
+            )
+    else:
+        # Create a new revision with the specified URL.
+        with _spinner(console, "Deploying..."):
+            revision_id = client.create_agent_revision(
+                config.handle,
+                make_current=make_current,
+                metadata=metadata_dict,
+                external_url=config.deployment_url,
+                reindex_corpora=reindex,
+            )
 
-            tarball_file.seek(0)
-            with _spinner(console, "Deploying..."):
-                ctx.obj.client.deploy_agent(
-                    config.handle,
-                    tarball_file,
-                )
+    sample_queries = client.gqlclient.execute(
+        gql(
+            """
+            query GetSampleQueries($agentId: String!) {
+                agentById(agentId: $agentId) {
+                    queries
+                }
+            }
+            """
+        ),
+        variable_values={"agentId": agent_id},
+    )
 
-    # Trigger a refresh with the updated deployment
-    with _spinner(console, "Refreshing..."):
-        client.refresh_agent(config.handle)
-
-    agent_api.update_agent()
-    if agent_api.queries:
-        suggested_query = random.choice(agent_api.queries)
+    if sample_queries["agentById"]["queries"]:
+        suggested_query = random.choice(sample_queries["agentById"]["queries"])
     else:
         suggested_query = "Hello!"
 
-    suggested_command = (
-        f"fixie console --agent {agent_api.agent_id} {shlex.quote(suggested_query)}"
-    )
     console.print(
-        f"Your agent was deployed to {constants.FIXIE_API_URL}/agents/{agent_api.agent_id}\nYou can also chat with your agent using the fixie CLI:\n\n{suggested_command}"
+        f"Revision {revision_id} was deployed to {constants.FIXIE_API_URL}/agents/{agent_id}\n"
+        f"You can also chat with your agent using the fixie CLI:\n\n"
+        f"fixie console --agent {agent_id} {shlex.quote(suggested_query)}"
     )
 
 

--- a/fixieai/cli/agent/commands_test.py
+++ b/fixieai/cli/agent/commands_test.py
@@ -1,9 +1,12 @@
 import os
 import pathlib
+import queue
 import random
 import string
-import subprocess
-from unittest import mock
+import threading
+import time
+import unittest.mock
+from typing import Callable, Dict, Optional
 
 import click.testing
 import gql.client
@@ -14,7 +17,6 @@ import fixieai
 from fixieai import constants
 from fixieai.cli import cli
 from fixieai.cli.agent import agent_config
-from fixieai.client.client import FixieClient
 
 from . import commands
 
@@ -27,11 +29,12 @@ def mock_fixie_api_key(mocker):
 
 @pytest.fixture(autouse=True)
 def mock_graphql(mocker):
+    response_mocks: Dict[str, Callable] = {}
+
     def _execute(document, *args, **kwargs):
-        if document.definitions[0].name.value == "getUsername":
-            return {"user": {"username": "testuser"}}
-        elif document.definitions[0].name.value == "getAgentById":
-            return {
+        mocked_queries = {
+            "getUsername": {"user": {"username": "testuser"}},
+            "getAgentById": {
                 "agentById": {
                     "agentId": "testuser/testagent",
                     "handle": "testagent",
@@ -45,21 +48,90 @@ def mock_graphql(mocker):
                         "username": "testuser",
                     },
                 }
-            }
-        elif document.definitions[0].name.value == "UpdateAgent":
-            return {
+            },
+            "UpdateAgent": {
                 "updateAgent": {
                     "agent": {
                         "agentId": "testuser/testagent",
                     }
                 }
-            }
-        else:
-            raise ValueError(
-                "Unmocked GraphQL operation: " + document.definitions[0].name.value
-            )
+            },
+            "SetCurrentAgentRevision": {
+                "updateAgent": {
+                    "agent": {
+                        "agentId": "testuser/testagent",
+                    }
+                }
+            },
+            "CreateAgentRevision": {
+                "createAgentRevision": {"revision": {"id": "FAKEID"}}
+            },
+            "GetSampleQueries": {
+                "agentById": {"queries": ["Why did the chicken cross the road?"]}
+            },
+            "GetRevisionId": {"agentByHandle": {"currentRevision": {"id": "FAKEID"}}},
+            "DeleteRevision": {
+                "deleteAgentRevision": {"agent": {"agentId": "testuser/testagent"}}
+            },
+        }
 
-    return mocker.patch.object(gql.client.Client, "execute", side_effect=_execute)
+        operation = document.definitions[0].name.value
+        if operation in response_mocks:
+            return response_mocks[operation](document, *args, **kwargs)
+        if operation in mocked_queries:
+            return mocked_queries[operation]
+        else:
+            raise ValueError("Unmocked GraphQL operation: " + operation)
+
+    mocker.patch.object(gql.client.Client, "execute", side_effect=_execute)
+    return response_mocks
+
+
+@pytest.fixture(autouse=True)
+def mock_tunnel(mocker):
+    tunnel = mocker.patch("fixieai.cli.agent.tunnel.Tunnel")
+    tunnel.return_value.__enter__.return_value = ["mock://mock.example.com"]
+    return tunnel
+
+
+@pytest.fixture(autouse=True)
+def mock_fixie_requirement(mocker):
+    # Use the current version of fixieai as the fixie dependency.
+    mocker.patch.object(
+        commands,
+        "CURRENT_FIXIE_REQUIREMENT",
+        str(pathlib.Path(fixieai.__file__).parent.parent),
+    )
+
+
+@pytest.fixture()
+def mock_server_process_ctx(mocker):
+    mock_context_manager = unittest.mock.MagicMock()
+    mock_context_manager.stop_queue = queue.Queue()
+
+    def _server_process(console, event, *_, **__):
+        mock_process = unittest.mock.MagicMock()
+        mock_process.poll.return_value = None
+
+        def _stop(code):
+            mock_process.poll.return_value = code
+            mock_process.returncode = code
+            event.set()
+
+        def _enter(*args, **kwargs):
+            if mock_context_manager.stop_immediately == True:
+                _stop(0)
+            else:
+                mock_context_manager.stop_queue.put(_stop)
+
+            return mock_process
+
+        mock_context_manager.__enter__.side_effect = _enter
+        return mock_context_manager
+
+    mocker.patch.object(commands, "_server_process", side_effect=_server_process)
+
+    return mock_context_manager
 
 
 def test_update_agent_requirements_adds_fixie():
@@ -176,45 +248,211 @@ invalid URL
         assert config.more_info_url == ""
 
 
+def test_temporary_revision_replacer(mock_graphql):
+    mock_graphql["GetRevisionId"] = unittest.mock.MagicMock()
+    mock_graphql["CreateAgentRevision"] = unittest.mock.MagicMock()
+    mock_graphql["DeleteRevision"] = unittest.mock.MagicMock()
+    mock_graphql["SetCurrentAgentRevision"] = unittest.mock.MagicMock()
+
+    counter = 0
+
+    def next_revision_id():
+        nonlocal counter
+        counter += 1
+        return str(counter)
+
+    mock_graphql["GetRevisionId"].return_value = {
+        "agentByHandle": {"currentRevision": {"id": "0"}}
+    }
+    mock_graphql["CreateAgentRevision"].side_effect = lambda *_, **__: {
+        "createAgentRevision": {"revision": {"id": next_revision_id()}}
+    }
+
+    mock_console = unittest.mock.MagicMock()
+    with commands._temporary_revision_replacer(
+        mock_console, fixieai.FixieClient(), "testagent"
+    ) as replacer:
+        assert mock_graphql["CreateAgentRevision"].call_count == 0
+        replacer("mock://mock.example.org")
+        assert (
+            mock_graphql["CreateAgentRevision"].call_args[1]["variable_values"][
+                "externalDeployment"
+            ]["url"]
+            == "mock://mock.example.org"
+        )
+        assert mock_graphql["DeleteRevision"].call_count == 0
+        replacer("mock://mock2.example.org")
+        assert (
+            mock_graphql["CreateAgentRevision"].call_args[1]["variable_values"][
+                "externalDeployment"
+            ]["url"]
+            == "mock://mock2.example.org"
+        )
+        assert (
+            mock_graphql["DeleteRevision"].call_args[1]["variable_values"]["revisionId"]
+            == "1"
+        )
+
+
+def test_temporary_revision_replacer_no_current_revision(mock_graphql):
+    mock_graphql["GetRevisionId"] = unittest.mock.MagicMock()
+    mock_graphql["CreateAgentRevision"] = unittest.mock.MagicMock()
+    mock_graphql["DeleteRevision"] = unittest.mock.MagicMock()
+    mock_graphql["SetCurrentAgentRevision"] = unittest.mock.MagicMock()
+
+    counter = 0
+
+    def next_revision_id():
+        nonlocal counter
+        counter += 1
+        return str(counter)
+
+    mock_graphql["GetRevisionId"].return_value = {
+        "agentByHandle": {"currentRevision": None}
+    }
+    mock_graphql["CreateAgentRevision"].side_effect = lambda *_, **__: {
+        "createAgentRevision": {"revision": {"id": next_revision_id()}}
+    }
+
+    mock_console = unittest.mock.MagicMock()
+    with commands._temporary_revision_replacer(
+        mock_console, fixieai.FixieClient(), "testagent"
+    ) as replacer:
+        assert mock_graphql["CreateAgentRevision"].call_count == 0
+        replacer("mock://mock.example.org")
+        assert (
+            mock_graphql["CreateAgentRevision"].call_args[1]["variable_values"][
+                "externalDeployment"
+            ]["url"]
+            == "mock://mock.example.org"
+        )
+
+    # Exiting the context manager should delete the last revision.
+    assert (
+        mock_graphql["DeleteRevision"].call_args[1]["variable_values"]["revisionId"]
+        == "1"
+    )
+    assert mock_console["SetCurrentRevision"].call_count == 0
+
+
 @pytest.mark.parametrize(
     "command",
     [
-        ["agent", "serve", "--no-tunnel"],
-        ["agent", "serve", "foo/bar/baz", "--no-tunnel"],
+        ["agent", "serve"],
+        ["agent", "serve", "foo/bar/baz"],
         ["agent", "deploy", "--no-validate"],
         ["agent", "deploy", "foo/bar/baz", "--no-validate"],
         # venv provisioning takes a long time, so only test it once per command.
-        ["agent", "serve", "foo/bar/baz", "--no-tunnel", "--venv"],
+        ["agent", "serve", "foo/bar/baz", "--venv"],
         ["agent", "deploy", "foo/bar/baz", "--validate"],
     ],
 )
-def test_implicit_init(mocker, command):
+def test_implicit_init(mocker, command, mock_server_process_ctx):
     runner = click.testing.CliRunner()
     with runner.isolated_filesystem():
-        subprocess_run = subprocess.run
-
-        def mock_subprocess(cmd_args, *args, **kwargs):
-            if "uvicorn" in cmd_args:
-                # Mock out the uvicorn process.
-                return mock.MagicMock()
-
-            return subprocess_run(cmd_args, *args, **kwargs)
-
-        mocker.patch.object(subprocess, "run", side_effect=mock_subprocess)
-
-        # Use the current version of fixieai as the fixie dependency.
-        mocker.patch.object(
-            commands,
-            "CURRENT_FIXIE_REQUIREMENT",
-            str(pathlib.Path(fixieai.__file__).parent.parent),
-        )
-
-        # Mock out deployment API calls.
-        mocker.patch.object(FixieClient, "deploy_agent", return_value=None)
-        mocker.patch.object(FixieClient, "refresh_agent", return_value=None)
+        mock_server_process_ctx.stop_immediately = True
 
         result = runner.invoke(
             cli.fixie,
             command,
         )
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.stdout
+
+
+def test_fixie_serve_reload(mocker, mock_server_process_ctx):
+    runner = click.testing.CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli.fixie, ["agent", "init"])
+        assert result.exit_code == 0, result.stdout
+
+        # Wait a bit so that filesystem notifications from agent init don't appear as modifications.
+        time.sleep(1)
+
+        # Start the server.
+        def _run_in_background():
+            nonlocal result
+            result = runner.invoke(cli.fixie, ["agent", "serve", "--reload"])
+
+        background_thread = threading.Thread(target=_run_in_background, daemon=True)
+        background_thread.start()
+
+        # Wait for the server process to be "started".
+        stop_server = mock_server_process_ctx.stop_queue.get(timeout=5.0)
+
+        # It should not restart until we modify main.py.
+        with pytest.raises(queue.Empty):
+            _ = mock_server_process_ctx.stop_queue.get(timeout=0.5)
+
+        # Modify `main.py` and we should see the process get restarted.
+        pathlib.Path("main.py").touch()
+        stop_server = mock_server_process_ctx.stop_queue.get(timeout=5.0)
+        mock_server_process_ctx.__exit__.assert_called_once()
+
+        # Simulate the server process ending.
+        stop_server(0)
+        background_thread.join()
+        assert result.exit_code == 0, result.stdout
+
+
+def test_fixie_serve_tunnel_rotate(mock_graphql, mock_server_process_ctx, mock_tunnel):
+    # Mock the tunnel iterator with a blocking queue.
+    tunnel_queue: Optional[queue.Queue] = queue.Queue()
+
+    def _mock_tunnel_iter(*_, **__):
+        while tunnel_queue:
+            yield tunnel_queue.get()
+
+    mock_tunnel.return_value.__enter__.side_effect = _mock_tunnel_iter
+
+    # Mock revision creation
+    mock_revisions_queue: queue.Queue = queue.Queue()
+
+    def _mock_revision_creation(*args, **kwargs):
+        mock_revisions_queue.put((args, kwargs))
+        return {"createAgentRevision": {"revision": {"id": "FAKEID"}}}
+
+    mock_graphql["CreateAgentRevision"] = _mock_revision_creation
+
+    runner = click.testing.CliRunner()
+    with runner.isolated_filesystem():
+        result: Optional[click.testing.Result] = None
+
+        # Start the server.
+        def _run_in_background():
+            nonlocal result
+            result = runner.invoke(cli.fixie, ["agent", "serve"])
+            assert result.exit_code == 0, result.stdout
+
+        background_thread = threading.Thread(target=_run_in_background, daemon=True)
+        background_thread.start()
+
+        # Simulate the initial tunnel URL.
+        assert tunnel_queue
+        tunnel_queue.put("mock://tunnel1")
+
+        # Wait for the initial revision to be created.
+        (_, kwargs) = mock_revisions_queue.get(timeout=5.0)
+        assert (
+            kwargs["variable_values"]["externalDeployment"]["url"] == "mock://tunnel1"
+        )
+
+        # Rotate the tunnel and we should see a second revision created.
+        assert tunnel_queue
+        tunnel_queue.put("mock://tunnel2")
+        (_, kwargs) = mock_revisions_queue.get(timeout=5.0)
+        assert (
+            kwargs["variable_values"]["externalDeployment"]["url"] == "mock://tunnel2"
+        )
+
+        # Simulate the server process ending.
+        stop_server = mock_server_process_ctx.stop_queue.get(5.0)
+        stop_server(0)
+
+        # Close the mock tunnel.
+        assert tunnel_queue
+        tunnel_queue.put(None)
+        tunnel_queue = None
+
+        background_thread.join()
+        assert result
+        assert result.exit_code == 0, result.stdout

--- a/fixieai/cli/agent/loader.py
+++ b/fixieai/cli/agent/loader.py
@@ -97,6 +97,7 @@ def uvicorn_app_factory():
     fastapi_app = impl.app()
     fastapi_app.add_middleware(openai_proxy.OpenAIProxyRequestTokenForwarderMiddleware)
 
+    # The CLI no longer uses this, but continue to honor it to preserve compatibility with CLI 0.2.x.
     if os.getenv("FIXIE_REFRESH_ON_STARTUP") == "true":
         fastapi_app.add_event_handler(
             "startup", functools.partial(_refresh_agent_async, config.handle)

--- a/fixieai/client/agent.py
+++ b/fixieai/client/agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from gql import gql
@@ -271,6 +272,9 @@ class Agent:
         if query_url is not None:
             variable_values["queryUrl"] = query_url
         if func_url is not None:
+            warnings.warn(
+                "Setting func_url via create_agent is deprecated, use FixieClient.create_agent_revision instead."
+            )
             variable_values["funcUrl"] = func_url
         if more_info_url is not None:
             variable_values["moreInfoUrl"] = more_info_url
@@ -338,6 +342,9 @@ class Agent:
         if query_url is not None:
             variable_values["queryUrl"] = query_url
         if func_url is not None:
+            warnings.warn(
+                "Setting func_url via update_agent is deprecated, use FixieClient.create_agent_revision instead."
+            )
             variable_values["funcUrl"] = func_url
         if more_info_url is not None:
             variable_values["moreInfoUrl"] = more_info_url

--- a/fixieai/client/utils.py
+++ b/fixieai/client/utils.py
@@ -1,0 +1,44 @@
+import contextlib
+import functools
+from typing import BinaryIO, Optional
+
+from requests_toolbelt.multipart.encoder import MultipartEncoder  # type: ignore
+
+
+@contextlib.contextmanager
+def patched_gql_file_uploader(
+    file_like: Optional[BinaryIO], name: str, content_type: str
+):
+    """Applies a temporary patch to allow setting name and Content-Type on uploads via `gql`.
+
+    Future versions of `gql` will support setting Content-Type, but even with that support
+    `gql` requires that the stream being uploaded is named and FixieClient does not. So this
+    patches the underlying multipart encoder to assign the name and Content-Type to the specified
+    stream.
+    """
+
+    if file_like is None:
+        yield
+        return
+
+    @functools.wraps(MultipartEncoder.__init__)
+    def _patched_init(self, fields, *args, **kwargs):
+        patched_fields = {
+            k: (
+                (
+                    name,
+                    file_like,
+                    content_type,
+                )
+                if len(v) == 2 and v[1] == file_like
+                else v
+            )
+            for k, v in fields.items()
+        }
+        _patched_init.__wrapped__(self, patched_fields, *args, **kwargs)  # type: ignore
+
+    try:
+        MultipartEncoder.__init__ = _patched_init
+        yield
+    finally:
+        MultipartEncoder.__init__ = _patched_init.__wrapped__  # type: ignore

--- a/poetry.lock
+++ b/poetry.lock
@@ -653,7 +653,7 @@ requests = ">=2.5.0"
 
 [[package]]
 name = "orjson"
-version = "3.8.12"
+version = "3.8.13"
 description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
 category = "dev"
 optional = false
@@ -732,7 +732,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pydantic"
-version = "1.10.7"
+version = "1.10.8"
 description = "Data validation and settings management using python type hints"
 category = "main"
 optional = false
@@ -1005,7 +1005,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "4.5.0"
+version = "4.6.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
@@ -1166,7 +1166,7 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "1beeee3acfab15fdce6c48862c3a158ddabb000a516ce5cbc121f362cb62a06b"
+content-hash = "498e7bb8dcd5e4b740837a71924e92cb6ffa3a80ea9040a7d2963ff91cc29c2f"
 
 [metadata.files]
 anyio = [
@@ -1726,52 +1726,52 @@ oauth2-client = [
     {file = "oauth2_client-1.4.2-py3-none-any.whl", hash = "sha256:7b938ba8166128a3c4c15ad23ca0c95a2468f8e8b6069d019ebc73360c15c7ca"},
 ]
 orjson = [
-    {file = "orjson-3.8.12-cp310-cp310-macosx_11_0_x86_64.macosx_11_0_arm64.macosx_11_0_universal2.whl", hash = "sha256:c84046e890e13a119404a83f2e09e622509ed4692846ff94c4ca03654fbc7fb5"},
-    {file = "orjson-3.8.12-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29706dd8189835bcf1781faed286e99ae54fd6165437d364dfdbf0276bf39b19"},
-    {file = "orjson-3.8.12-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4e22b0aa70c963ac01fcd620de15be21a5027711b0e5d4b96debcdeea43e3ae"},
-    {file = "orjson-3.8.12-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6d1acf52d3a4b9384af09a5c2658c3a7a472a4d62a0ad1fe2c8fab8ef460c9b4"},
-    {file = "orjson-3.8.12-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a72b50719bdd6bb0acfca3d4d1c841aa4b191f3ff37268e7aba04e5d6be44ccd"},
-    {file = "orjson-3.8.12-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83e8c740a718fa6d511a82e463adc7ab17631c6eea81a716b723e127a9c51d57"},
-    {file = "orjson-3.8.12-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ebb03e4c7648f7bb299872002a6120082da018f41ba7a9ebf4ceae8d765443d2"},
-    {file = "orjson-3.8.12-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:44f7bb4c995652106276442de1147c9993716d1e2d79b7fd435afa154ff236b9"},
-    {file = "orjson-3.8.12-cp310-none-win_amd64.whl", hash = "sha256:06e528f9a84fbb4000fd0eee573b5db543ee70ae586fdbc53e740b0ac981701c"},
-    {file = "orjson-3.8.12-cp311-cp311-macosx_11_0_x86_64.macosx_11_0_arm64.macosx_11_0_universal2.whl", hash = "sha256:9a6c1594d5a9ff56e5babc4a87ac372af38d37adef9e06744e9f158431e33f43"},
-    {file = "orjson-3.8.12-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6390ce0bce24c107fc275736aa8a4f768ef7eb5df935d7dca0cc99815eb5d99"},
-    {file = "orjson-3.8.12-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:efb3a10030462a22c731682434df5c137a67632a8339f821cd501920b169007e"},
-    {file = "orjson-3.8.12-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7e405d54c84c30d9b1c918c290bcf4ef484a45c69d5583a95db81ffffba40b44"},
-    {file = "orjson-3.8.12-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd6fbd1413559572e81b5ac64c45388147c3ba85cc3df2eaa11002945e0dbd1f"},
-    {file = "orjson-3.8.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f480ae7b84369b1860d8867f0baf8d885fede400fda390ce088bfa8edf97ffdc"},
-    {file = "orjson-3.8.12-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:355055e0977c43b0e5325b9312b7208c696fe20cd54eed1d6fc80b0a4d6721f5"},
-    {file = "orjson-3.8.12-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d937503e4dfba5edc8d5e0426d3cc97ed55716e93212b2e12a198664487b9965"},
-    {file = "orjson-3.8.12-cp311-none-win_amd64.whl", hash = "sha256:eb16e0195febd24b44f4db1ab3be85ecf6038f92fd511370cebc004b3d422294"},
-    {file = "orjson-3.8.12-cp37-cp37m-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:dc27a8ec13f28e92dc1ea89bf1232d77e7d3ebfd5c1ccf4f3729a70561cb63bd"},
-    {file = "orjson-3.8.12-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77710774faed337ac4ad919dadc5f3b655b0cd40518e5386e6f1f116de9c6c25"},
-    {file = "orjson-3.8.12-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7e549468867991f6f9cfbd9c5bbc977330173bd8f6ceb79973bbd4634e13e1b9"},
-    {file = "orjson-3.8.12-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:96fb1eb82b578eb6c0e53e3cf950839fe98ea210626f87c8204bd4fc2cc6ba02"},
-    {file = "orjson-3.8.12-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d153b228b6e24f8bccf732a51e01e8e938eef59efed9030c5c257778fbe0804"},
-    {file = "orjson-3.8.12-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:becbd5af6d035a7ec2ee3239d4700929d52d8517806b97dd04efcc37289403f7"},
-    {file = "orjson-3.8.12-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7d63f524048825e05950db3b6998c756d5377a5e8c469b2e3bdb9f3217523d74"},
-    {file = "orjson-3.8.12-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ec4f0130d9a27cb400423e09e0f9e46480e9e977f05fdcf663a7a2c68735513e"},
-    {file = "orjson-3.8.12-cp37-none-win_amd64.whl", hash = "sha256:6f1b01f641f5e87168b819ac1cbd81aa6278e7572c326f3d27e92dea442a2c0d"},
-    {file = "orjson-3.8.12-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:062e67108c218fdb9475edd5272b1629c05b56c66416fa915de5656adde30e73"},
-    {file = "orjson-3.8.12-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ba645c92801417933fa74448622ba614a275ea82df05e888095c7742d913bb4"},
-    {file = "orjson-3.8.12-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7d50d9b1ae409ea15534365fec0ce8a5a5f7dc94aa790aacfb8cfec87ab51aa4"},
-    {file = "orjson-3.8.12-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f00038bf5d07439d13c0c2c5cd6ad48eb86df7dbd7a484013ce6a113c421b14"},
-    {file = "orjson-3.8.12-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:397670665f94cf5cff779054781d80395084ba97191d82f7b3a86f0a20e6102b"},
-    {file = "orjson-3.8.12-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f568205519bb0197ca91915c5da6058cfbb59993e557b02dfc3b2718b34770a"},
-    {file = "orjson-3.8.12-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4fd240e736ce52cd757d74142d9933fd35a3184396be887c435f0574e0388654"},
-    {file = "orjson-3.8.12-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6cae2ff288a80e81ce30313e735c5436495ab58cf8d4fbe84900e616d0ee7a78"},
-    {file = "orjson-3.8.12-cp38-none-win_amd64.whl", hash = "sha256:710c40c214b753392e46f9275fd795e9630dd737a5ab4ac6e4ee1a02fe83cc0d"},
-    {file = "orjson-3.8.12-cp39-cp39-macosx_11_0_x86_64.macosx_11_0_arm64.macosx_11_0_universal2.whl", hash = "sha256:aff761de5ed5543a0a51e9f703668624749aa2239de5d7d37d9c9693daeaf5dc"},
-    {file = "orjson-3.8.12-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:135f29cf936283a0cd1b8bce86540ca181108f2a4d4483eedad6b8026865d2a9"},
-    {file = "orjson-3.8.12-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62f999798f2fa55e567d483864ebfc30120fb055c2696a255979439323a5b15c"},
-    {file = "orjson-3.8.12-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3fa58ca064c640fa9d823f98fbbc8e71940ecb78cea3ac2507da1cbf49d60b51"},
-    {file = "orjson-3.8.12-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8682f752c19f6a7d9fc727fd98588b4c8b0dce791b5794bb814c7379ccd64a79"},
-    {file = "orjson-3.8.12-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de3d096dde3e46d01841abc1982b906694ab3c92f338d37a2e6184739dc8a958"},
-    {file = "orjson-3.8.12-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:834b50df79f1fe89bbaced3a1c1d8c8c92cc99e84cdcd374d8da4974b3560d2a"},
-    {file = "orjson-3.8.12-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2ad149ed76dce2bbdfbadd61c35959305e77141badf364a158beb4ef3d88ec37"},
-    {file = "orjson-3.8.12-cp39-none-win_amd64.whl", hash = "sha256:82d65e478a21f98107b4eb8390104746bb3024c27084b57edab7d427385f1f70"},
-    {file = "orjson-3.8.12.tar.gz", hash = "sha256:9f0f042cf002a474a6aea006dd9f8d7a5497e35e5fb190ec78eb4d232ec19955"},
+    {file = "orjson-3.8.13-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:bf934a036dafe63c3b1d630efaf996b85554e7ab03754019a18cc0fe2bdcc3a9"},
+    {file = "orjson-3.8.13-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1316c60c0f55440e765b0211e94d171ab2c11d00fe8dcf0ac70c9bd1d9818e6b"},
+    {file = "orjson-3.8.13-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4b98fbca0ea0f5e56b3c1d050b78460ca9708419780ec218cef1eca424db2ee5"},
+    {file = "orjson-3.8.13-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c97be6a6ff4d546579f08f1d67aad92715313a06b214e3f2df9bb9f1b45765c2"},
+    {file = "orjson-3.8.13-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e62f14f3eabccdd2108e3d5884fb66197255accc42b9ffa7f04d9dbf7336b479"},
+    {file = "orjson-3.8.13-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d2e9a8ea45db847864868f7a566bece7d425c06627e5dbdd5fc8399a9c3330b"},
+    {file = "orjson-3.8.13-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:637d55ba6b48b698973d7e647b9de6bb2b424c445f51c86df4e976e672300b21"},
+    {file = "orjson-3.8.13-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6b323bb4af76c16636ac1fec403331208f978ae8a2c6bcab904ee1683c05ad7a"},
+    {file = "orjson-3.8.13-cp310-none-win_amd64.whl", hash = "sha256:246e22d167ede9ebf09685587187bde9e2440a515bd5eab2e97f029b9de57677"},
+    {file = "orjson-3.8.13-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:156bd6325a4f4a0c88556b7d774e3e18713c8134b6f807571a3eec14dfcafff6"},
+    {file = "orjson-3.8.13-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8d2ce41c5992dbe9962ef75db1e70ed33636959f2f4b929f9d8cbb2e30472a08"},
+    {file = "orjson-3.8.13-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:50cfa3449157c4a4ad017a041dbb5fe37091800220fd5e651c0e5fff63bdac61"},
+    {file = "orjson-3.8.13-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:59d81f5b9e280ac3ced615e726bfba722785cc5f7fc3aa1e0ea304c5a4114e94"},
+    {file = "orjson-3.8.13-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:59d79e5de4a1de246517b4c92dcf6a7ef1fb12e3ce4bbfc6c0f99d1d905405fd"},
+    {file = "orjson-3.8.13-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97d8444cf48f8fe2718fd3b99484906c29a909dc3a8177e8751170a9a28bcf33"},
+    {file = "orjson-3.8.13-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:f084ce58b3fd496429deb3435aa7295ab57e349a33cdb99b3cb5f0a66a610a84"},
+    {file = "orjson-3.8.13-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:ce737ddf9d5f960996b63c12dbcc82ae2315c45f19165b2fe14a5b33ab8705bb"},
+    {file = "orjson-3.8.13-cp311-none-win_amd64.whl", hash = "sha256:305ffd227857cede7318c056020d1a3f3295e8adf8e7f2cbd78c26c530a0f234"},
+    {file = "orjson-3.8.13-cp37-cp37m-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:0055168bc38c9caf7211e66e7c06d7f127d2c1dd1cd1d806c58f3a81d6074a6c"},
+    {file = "orjson-3.8.13-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc42b2006abaa4fb72c9193931a9236dd85ce0483cc74079c315ce8529568ca1"},
+    {file = "orjson-3.8.13-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6dcccda35f11f12ebb36db0ebdca9854327530e1fffe02331cde78177851ae7f"},
+    {file = "orjson-3.8.13-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1234110f782af5e81893b5419b9374ca2559dbd976cbd515e6c3afc292cdfb6a"},
+    {file = "orjson-3.8.13-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d30b8b9fe1ff56fb6ff64d2c2e227d49819b58ae8dac51089f393e31b39a4080"},
+    {file = "orjson-3.8.13-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24f923cf8d7e2e9a975f4507f93e93c262f26b4a1a4f72e4d6e75eda45de8f40"},
+    {file = "orjson-3.8.13-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:17788155c50f47d9fd037e12ac82a57381c157ea4de50e8946df8519da0f7f02"},
+    {file = "orjson-3.8.13-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:05bfef2719d68b44ab38061f9cd2b3a58d9994f7230734ba6d3c16db97c5e94a"},
+    {file = "orjson-3.8.13-cp37-none-win_amd64.whl", hash = "sha256:6fe2981bd0f6959d821253604e9ba2c5ffa03c6202d11f0e3c190e5712b6835b"},
+    {file = "orjson-3.8.13-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:2e362090bdd4261608eceefd8ed127cd2bfc48643601f9c0cf5d162ca6a7c4cd"},
+    {file = "orjson-3.8.13-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a3bc7e12f69f7bcefe522c4e4dac33a9b3b450aae0b3170ab61fbce0a6e1b37"},
+    {file = "orjson-3.8.13-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e56ca7bd82b25f40955184df21c977369debe51c4b83fc3113b6427726312f3"},
+    {file = "orjson-3.8.13-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e792d286ad175d36f6b77b7ba77f1654a13f705a7ccfef7819e9b6d49277120d"},
+    {file = "orjson-3.8.13-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cf79f51a7ca59ac322a1e65430142ab1cb9c9a845e893e0e3958deaefe1c9873"},
+    {file = "orjson-3.8.13-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41585f90cfe24d0ae7d5bc96968617b8bcebb618e19db5b0bbadce6bc82f3455"},
+    {file = "orjson-3.8.13-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9b5b005841394e563f1ca3314a6884101a1b1f1dd30c569b4a0335e1ebf49fbf"},
+    {file = "orjson-3.8.13-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8075487b7b2e7cc2c44d8ee7950845b6854cd08a04df80b36055cc0236c28edd"},
+    {file = "orjson-3.8.13-cp38-none-win_amd64.whl", hash = "sha256:0ca2aced3fa6ce6d440a2a2e55bb7618fd24fce146068523472f349598e992ee"},
+    {file = "orjson-3.8.13-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:f8aa77df01c60b7d8b0ff5501d6b8583a4acb06c4373c59bf769025ff8b8b4cb"},
+    {file = "orjson-3.8.13-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea6899624661d2258a71bde33266c3c08c8d9596865acf0ac19a9552c08fa1a6"},
+    {file = "orjson-3.8.13-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:11a457fafdd207f361986750a5229fc36911fc9fdfc274d078fdf1654845ef45"},
+    {file = "orjson-3.8.13-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:386e60a09585b2b5db84879ebad6d49427ae5a9677f86a90bff9cbbec42b03be"},
+    {file = "orjson-3.8.13-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b05ef096362c8a96fdcd85392c68156c9b680271aea350b490c2d0f3ef1b6b6a"},
+    {file = "orjson-3.8.13-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5492a1d9eea5a1cb33ae6d225091c69dc79f16d952885625c00070388489d412"},
+    {file = "orjson-3.8.13-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:47cb98386a7ff79d0ace6a7c9d5c49ca2b4ea42e4339c565f5efe7757790dd04"},
+    {file = "orjson-3.8.13-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a4a182e7a58114a81d52d67bdc034eb83571690158c4b8d3f1bf5c5f772f77b1"},
+    {file = "orjson-3.8.13-cp39-none-win_amd64.whl", hash = "sha256:b2325d8471867c99c432c96861d72d8b7336293860ebb17c9d70e1d377cc2b32"},
+    {file = "orjson-3.8.13.tar.gz", hash = "sha256:14e54713703d5436a7be54ff50d780b6b09358f1a0be6107a3ea4f3537a4f6d8"},
 ]
 packaging = [
     {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
@@ -1866,42 +1866,42 @@ pycparser = [
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
 pydantic = [
-    {file = "pydantic-1.10.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e79e999e539872e903767c417c897e729e015872040e56b96e67968c3b918b2d"},
-    {file = "pydantic-1.10.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:01aea3a42c13f2602b7ecbbea484a98169fb568ebd9e247593ea05f01b884b2e"},
-    {file = "pydantic-1.10.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:516f1ed9bc2406a0467dd777afc636c7091d71f214d5e413d64fef45174cfc7a"},
-    {file = "pydantic-1.10.7-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae150a63564929c675d7f2303008d88426a0add46efd76c3fc797cd71cb1b46f"},
-    {file = "pydantic-1.10.7-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ecbbc51391248116c0a055899e6c3e7ffbb11fb5e2a4cd6f2d0b93272118a209"},
-    {file = "pydantic-1.10.7-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f4a2b50e2b03d5776e7f21af73e2070e1b5c0d0df255a827e7c632962f8315af"},
-    {file = "pydantic-1.10.7-cp310-cp310-win_amd64.whl", hash = "sha256:a7cd2251439988b413cb0a985c4ed82b6c6aac382dbaff53ae03c4b23a70e80a"},
-    {file = "pydantic-1.10.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:68792151e174a4aa9e9fc1b4e653e65a354a2fa0fed169f7b3d09902ad2cb6f1"},
-    {file = "pydantic-1.10.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfe2507b8ef209da71b6fb5f4e597b50c5a34b78d7e857c4f8f3115effaef5fe"},
-    {file = "pydantic-1.10.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10a86d8c8db68086f1e30a530f7d5f83eb0685e632e411dbbcf2d5c0150e8dcd"},
-    {file = "pydantic-1.10.7-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d75ae19d2a3dbb146b6f324031c24f8a3f52ff5d6a9f22f0683694b3afcb16fb"},
-    {file = "pydantic-1.10.7-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:464855a7ff7f2cc2cf537ecc421291b9132aa9c79aef44e917ad711b4a93163b"},
-    {file = "pydantic-1.10.7-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:193924c563fae6ddcb71d3f06fa153866423ac1b793a47936656e806b64e24ca"},
-    {file = "pydantic-1.10.7-cp311-cp311-win_amd64.whl", hash = "sha256:b4a849d10f211389502059c33332e91327bc154acc1845f375a99eca3afa802d"},
-    {file = "pydantic-1.10.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cc1dde4e50a5fc1336ee0581c1612215bc64ed6d28d2c7c6f25d2fe3e7c3e918"},
-    {file = "pydantic-1.10.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e0cfe895a504c060e5d36b287ee696e2fdad02d89e0d895f83037245218a87fe"},
-    {file = "pydantic-1.10.7-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:670bb4683ad1e48b0ecb06f0cfe2178dcf74ff27921cdf1606e527d2617a81ee"},
-    {file = "pydantic-1.10.7-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:950ce33857841f9a337ce07ddf46bc84e1c4946d2a3bba18f8280297157a3fd1"},
-    {file = "pydantic-1.10.7-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c15582f9055fbc1bfe50266a19771bbbef33dd28c45e78afbe1996fd70966c2a"},
-    {file = "pydantic-1.10.7-cp37-cp37m-win_amd64.whl", hash = "sha256:82dffb306dd20bd5268fd6379bc4bfe75242a9c2b79fec58e1041fbbdb1f7914"},
-    {file = "pydantic-1.10.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c7f51861d73e8b9ddcb9916ae7ac39fb52761d9ea0df41128e81e2ba42886cd"},
-    {file = "pydantic-1.10.7-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6434b49c0b03a51021ade5c4daa7d70c98f7a79e95b551201fff682fc1661245"},
-    {file = "pydantic-1.10.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d34ab766fa056df49013bb6e79921a0265204c071984e75a09cbceacbbdd5d"},
-    {file = "pydantic-1.10.7-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:701daea9ffe9d26f97b52f1d157e0d4121644f0fcf80b443248434958fd03dc3"},
-    {file = "pydantic-1.10.7-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:cf135c46099ff3f919d2150a948ce94b9ce545598ef2c6c7bf55dca98a304b52"},
-    {file = "pydantic-1.10.7-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b0f85904f73161817b80781cc150f8b906d521fa11e3cdabae19a581c3606209"},
-    {file = "pydantic-1.10.7-cp38-cp38-win_amd64.whl", hash = "sha256:9f6f0fd68d73257ad6685419478c5aece46432f4bdd8d32c7345f1986496171e"},
-    {file = "pydantic-1.10.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c230c0d8a322276d6e7b88c3f7ce885f9ed16e0910354510e0bae84d54991143"},
-    {file = "pydantic-1.10.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:976cae77ba6a49d80f461fd8bba183ff7ba79f44aa5cfa82f1346b5626542f8e"},
-    {file = "pydantic-1.10.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d45fc99d64af9aaf7e308054a0067fdcd87ffe974f2442312372dfa66e1001d"},
-    {file = "pydantic-1.10.7-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d2a5ebb48958754d386195fe9e9c5106f11275867051bf017a8059410e9abf1f"},
-    {file = "pydantic-1.10.7-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:abfb7d4a7cd5cc4e1d1887c43503a7c5dd608eadf8bc615413fc498d3e4645cd"},
-    {file = "pydantic-1.10.7-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:80b1fab4deb08a8292d15e43a6edccdffa5377a36a4597bb545b93e79c5ff0a5"},
-    {file = "pydantic-1.10.7-cp39-cp39-win_amd64.whl", hash = "sha256:d71e69699498b020ea198468e2480a2f1e7433e32a3a99760058c6520e2bea7e"},
-    {file = "pydantic-1.10.7-py3-none-any.whl", hash = "sha256:0cd181f1d0b1d00e2b705f1bf1ac7799a2d938cce3376b8007df62b29be3c2c6"},
-    {file = "pydantic-1.10.7.tar.gz", hash = "sha256:cfc83c0678b6ba51b0532bea66860617c4cd4251ecf76e9846fa5a9f3454e97e"},
+    {file = "pydantic-1.10.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1243d28e9b05003a89d72e7915fdb26ffd1d39bdd39b00b7dbe4afae4b557f9d"},
+    {file = "pydantic-1.10.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c0ab53b609c11dfc0c060d94335993cc2b95b2150e25583bec37a49b2d6c6c3f"},
+    {file = "pydantic-1.10.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9613fadad06b4f3bc5db2653ce2f22e0de84a7c6c293909b48f6ed37b83c61f"},
+    {file = "pydantic-1.10.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:df7800cb1984d8f6e249351139667a8c50a379009271ee6236138a22a0c0f319"},
+    {file = "pydantic-1.10.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0c6fafa0965b539d7aab0a673a046466d23b86e4b0e8019d25fd53f4df62c277"},
+    {file = "pydantic-1.10.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e82d4566fcd527eae8b244fa952d99f2ca3172b7e97add0b43e2d97ee77f81ab"},
+    {file = "pydantic-1.10.8-cp310-cp310-win_amd64.whl", hash = "sha256:ab523c31e22943713d80d8d342d23b6f6ac4b792a1e54064a8d0cf78fd64e800"},
+    {file = "pydantic-1.10.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:666bdf6066bf6dbc107b30d034615d2627e2121506c555f73f90b54a463d1f33"},
+    {file = "pydantic-1.10.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:35db5301b82e8661fa9c505c800d0990bc14e9f36f98932bb1d248c0ac5cada5"},
+    {file = "pydantic-1.10.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f90c1e29f447557e9e26afb1c4dbf8768a10cc676e3781b6a577841ade126b85"},
+    {file = "pydantic-1.10.8-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:93e766b4a8226e0708ef243e843105bf124e21331694367f95f4e3b4a92bbb3f"},
+    {file = "pydantic-1.10.8-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:88f195f582851e8db960b4a94c3e3ad25692c1c1539e2552f3df7a9e972ef60e"},
+    {file = "pydantic-1.10.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:34d327c81e68a1ecb52fe9c8d50c8a9b3e90d3c8ad991bfc8f953fb477d42fb4"},
+    {file = "pydantic-1.10.8-cp311-cp311-win_amd64.whl", hash = "sha256:d532bf00f381bd6bc62cabc7d1372096b75a33bc197a312b03f5838b4fb84edd"},
+    {file = "pydantic-1.10.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7d5b8641c24886d764a74ec541d2fc2c7fb19f6da2a4001e6d580ba4a38f7878"},
+    {file = "pydantic-1.10.8-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b1f6cb446470b7ddf86c2e57cd119a24959af2b01e552f60705910663af09a4"},
+    {file = "pydantic-1.10.8-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c33b60054b2136aef8cf190cd4c52a3daa20b2263917c49adad20eaf381e823b"},
+    {file = "pydantic-1.10.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:1952526ba40b220b912cdc43c1c32bcf4a58e3f192fa313ee665916b26befb68"},
+    {file = "pydantic-1.10.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:bb14388ec45a7a0dc429e87def6396f9e73c8c77818c927b6a60706603d5f2ea"},
+    {file = "pydantic-1.10.8-cp37-cp37m-win_amd64.whl", hash = "sha256:16f8c3e33af1e9bb16c7a91fc7d5fa9fe27298e9f299cff6cb744d89d573d62c"},
+    {file = "pydantic-1.10.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1ced8375969673929809d7f36ad322934c35de4af3b5e5b09ec967c21f9f7887"},
+    {file = "pydantic-1.10.8-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:93e6bcfccbd831894a6a434b0aeb1947f9e70b7468f274154d03d71fabb1d7c6"},
+    {file = "pydantic-1.10.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:191ba419b605f897ede9892f6c56fb182f40a15d309ef0142212200a10af4c18"},
+    {file = "pydantic-1.10.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:052d8654cb65174d6f9490cc9b9a200083a82cf5c3c5d3985db765757eb3b375"},
+    {file = "pydantic-1.10.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ceb6a23bf1ba4b837d0cfe378329ad3f351b5897c8d4914ce95b85fba96da5a1"},
+    {file = "pydantic-1.10.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6f2e754d5566f050954727c77f094e01793bcb5725b663bf628fa6743a5a9108"},
+    {file = "pydantic-1.10.8-cp38-cp38-win_amd64.whl", hash = "sha256:6a82d6cda82258efca32b40040228ecf43a548671cb174a1e81477195ed3ed56"},
+    {file = "pydantic-1.10.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3e59417ba8a17265e632af99cc5f35ec309de5980c440c255ab1ca3ae96a3e0e"},
+    {file = "pydantic-1.10.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:84d80219c3f8d4cad44575e18404099c76851bc924ce5ab1c4c8bb5e2a2227d0"},
+    {file = "pydantic-1.10.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e4148e635994d57d834be1182a44bdb07dd867fa3c2d1b37002000646cc5459"},
+    {file = "pydantic-1.10.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:12f7b0bf8553e310e530e9f3a2f5734c68699f42218bf3568ef49cd9b0e44df4"},
+    {file = "pydantic-1.10.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:42aa0c4b5c3025483240a25b09f3c09a189481ddda2ea3a831a9d25f444e03c1"},
+    {file = "pydantic-1.10.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:17aef11cc1b997f9d574b91909fed40761e13fac438d72b81f902226a69dac01"},
+    {file = "pydantic-1.10.8-cp39-cp39-win_amd64.whl", hash = "sha256:66a703d1983c675a6e0fed8953b0971c44dba48a929a2000a493c3772eb61a5a"},
+    {file = "pydantic-1.10.8-py3-none-any.whl", hash = "sha256:7456eb22ed9aaa24ff3e7b4757da20d9e5ce2a81018c1b3ebd81a0b88a18f3b2"},
+    {file = "pydantic-1.10.8.tar.gz", hash = "sha256:1410275520dfa70effadf4c21811d755e7ef9bb1f1d077a21958153a92c8d9ca"},
 ]
 pyflakes = [
     {file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
@@ -2026,8 +2026,8 @@ types-setuptools = [
     {file = "types_setuptools-67.8.0.0-py3-none-any.whl", hash = "sha256:6df73340d96b238a4188b7b7668814b37e8018168aef1eef94a3b1872e3f60ff"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
-    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
+    {file = "typing_extensions-4.6.0-py3-none-any.whl", hash = "sha256:6ad00b63f849b7dcc313b70b6b304ed67b2b2963b3098a33efe18056b1a9a223"},
+    {file = "typing_extensions-4.6.0.tar.gz", hash = "sha256:ff6b238610c747e44c268aa4bb23c8c735d665a63726df3f9431ce707f2aa768"},
 ]
 typing-inspect = [
     {file = "typing_inspect-0.8.0-py3-none-any.whl", hash = "sha256:5fbf9c1e65d4fa01e701fe12a5bca6c6e08a4ffd5bc60bfac028253a447c5188"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ fixieai = "fixieai.cli.cli:fixie"
 click = "^8.1.3"
 fastapi = { version = "^0.89.1" }
 uvicorn = { version = "^0.20.0", extras = ["standard"] }
-gql = { version = "^3.4.0", extras = ["requests"] }
+gql = { version = "^3.4.1", extras = ["requests"] }
 python = "^3.8"
 prompt-toolkit = "*"
-pydantic = "*"
+pydantic = ">=1.10.8"
 PyJWT = { version = "^2.6.0", extras = ["crypto"] }
 requests = "^2.28.1"
 rich = "^12.6.0"
@@ -34,8 +34,7 @@ Pillow = "*"
 python-dotenv = "^1.0.0"
 packaging = "^23.0"
 wrapt = "^1.15.0"
-urllib3 = ">=1,<2" # gql requires requests_toolbelt < 1 which requires urllib3 < 2.0
-typing-extensions = "<4.6.0" # 4.6.0 has a breaking change that causes `TypeError: issubclass() arg 1 must be a class`
+watchfiles = "^0.19.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.3"


### PR DESCRIPTION
This adds revisions-related commands to the CLI and methods to `FixieClient`. Notably:
- `fixie agent revisions list` lists all revisions associated with an agent
- `fixie agent revisions set-current` sets the current revision
- `fixie agent revisions delete` deletes a revision

Additionally, this changes the `fixie agent serve` and `fixie agent deploy` commands to use the revisions API. Functionally this means:
- `fixie serve` restores the pre-existing revision when exiting and deletes ephemeral revisions
- `fixie deploy` now supports corpora reindexing, deploying a non-current revision, and tagging revisions with user-provided metadata

From an implementation standpoint, this requires removing a dependency on the "refresh-on-startup" hook so that the CLI can actively manage (and dispose of) the ephemeral revisions. The CLI now
- polls the host/port to see when the server has started up
- handles server reloads itself rather than delegating it to `uvicorn`