### PR TITLE
Fix corpus response encoding by using the encoder we defined instead …

### DIFF
--- a/fixieai/agents/agent_base.py
+++ b/fixieai/agents/agent_base.py
@@ -258,7 +258,7 @@ class AgentBase(abc.ABC):
         credentials: fastapi.security.HTTPAuthorizationCredentials = fastapi.Depends(
             fastapi.security.HTTPBearer()
         ),
-    ) -> corpora.CorpusResponse:
+    ) -> fastapi.responses.JSONResponse:
         """Verifies the request is a valid request from Fixie, and dispatches it to
         the appropriate corpus function.
         """
@@ -278,7 +278,11 @@ class AgentBase(abc.ABC):
 
         output = pyfunc(request, token_claims)
 
-        return next(iter(output))
+        result = next(iter(output))
+        # Use dataclasses_json instead of FastAPI's default json encoder. This
+        # allows us to use our own bytes encoder instead of the default, which
+        # always uses utf-8 and therefore wouldn't allow some characters.
+        return fastapi.responses.JSONResponse(result.to_dict())
 
     def _check_credentials(
         self, credentials: fastapi.security.HTTPAuthorizationCredentials

--- a/fixieai/agents/agent_base_test.py
+++ b/fixieai/agents/agent_base_test.py
@@ -27,7 +27,7 @@ CORPUS_RESPONSE_JSON = {
         "documents": [
             {
                 "source_name": "doc1",
-                "content": "doc1Content",
+                "content": "ZG9jMUNvbnRlbnQ=",
                 "mime_type": "text/plain",
                 "encoding": "UTF-8",
             }


### PR DESCRIPTION
…of the fastapi default.