### PR TITLE
Add section about custom corpora to docs QA page.

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -8,7 +8,7 @@ See [Fixie Agent Python API](python-agent-api.md) for the full API reference.
 
 ## CodeShotAgent
 
-The base class for agents in Fixie is [`CodeShotAgent`][fixieai.agents.code_shot.codeshotagent]. This class handles communication with the Fixie platform via the [Agent Protocol](agent-protocol.md) and provides a simple API for registering functions that can be invoked by the few-shot examples used by the agent.
+The base class for agents in Fixie is [`CodeShotAgent`][fixieai.agents.code_shot.CodeShotAgent]. This class handles communication with the Fixie platform via the [Agent Protocol](agent-protocol.md) and provides a simple API for registering functions that can be invoked by the few-shot examples used by the agent.
 
 A typical `CodeShotAgent` structure looks like this:
 
@@ -56,19 +56,19 @@ def my_func(query, user_storage=None, oauth_handler=None):
     ...
 ```
 
-The `query` parameter is either a `str` or a [`Message`][fixieai.agents.api.message] object. If the query parameter is a string, this parameter contains the text of the agent query. If the query parameter is a `Message` object, this parameter contains the text of the agent along with zero or more [`Embed`][fixieai.agents.api.embed] objects, as described in the [Embeds](#embeds) section below.
+The `query` parameter is either a `str` or a [`Message`][fixieai.agents.api.Message] object. If the query parameter is a string, this parameter contains the text of the agent query. If the query parameter is a `Message` object, this parameter contains the text of the agent along with zero or more [`Embed`][fixieai.agents.api.Embed] objects, as described in the [Embeds](#embeds) section below.
 
 The optional `user_storage` parameter provides the Func an interface to the Fixie [User Storage](#user-storage) service, as described below.
 
 The optional `oauth_handler` parameter provides the Func an interface for performing OAuth authentication with external services, as described in the [OAuth](#agent-oauth-support) section below.
 
-The function must return either a `str` or a [`Message`][fixieai.agents.api.message] object. Returning a string is equivalent to returning a `Message` object with the string as its `text` field and no `embeds`.
+The function must return either a `str` or a [`Message`][fixieai.agents.api.Message] object. Returning a string is equivalent to returning a `Message` object with the string as its `text` field and no `embeds`.
 
 ## Embeds
 
 **Embeds** enable the association of arbitrary binary data with a query or response Message in Fixie, similar to email attachments. Embeds can be used to store images, videos, text, or any other binary data.
 
-Embeds are represented by the [`Embed`][fixieai.agents.api.embed] class. Agents can access the Embeds associated with a Message as follows:
+Embeds are represented by the [`Embed`][fixieai.agents.api.Embed] class. Agents can access the Embeds associated with a Message as follows:
 
 ```python
 @agent.register_func()
@@ -112,7 +112,7 @@ Note: It can take up to 10 minutes to index content, depending on the number of 
 
 ## User Storage
 
-Fixie agents can store and retrieve arbitrary data associated with a user using the [`UserStorage`][fixieai.agents.userstorage] class. This class provides a simple interface to a persistent key/value storage service, with a separate key/value store for each Fixie user. This can be used to maintain state about a particular user that persists across agent invocations.
+Fixie agents can store and retrieve arbitrary data associated with a user using the [`UserStorage`][fixieai.agents.user_storage.UserStorage] class. This class provides a simple interface to a persistent key/value storage service, with a separate key/value store for each Fixie user. This can be used to maintain state about a particular user that persists across agent invocations.
 
 The `UserStorage` instance for a given query can be obtained by providing a `user_storage` parameter to an agent function. The `UserStorage` object acts as a Python `dict` that stores state associated with an arbitrary string key. `UserStorage` values may consist of Python primitive types, such as `str`, `int`, `float`, `bool`, `None`, or `bytes`, as well as lists of these types, or a `dict` mapping a `str` to one of these types.
 
@@ -129,7 +129,7 @@ def my_func(query: fixieai.Message, user_storage: fixieai.UserStorage) -> str:
 
 Fixie Agents can authenticate to third-party services to perform actions on behalf of the user. This is done using OAuth 2.0, a standard protocol for authorization. OAuth 2.0 allows users to grant limited access to their accounts on one service, to another service, without having to share their password.
 
-Fixie provides a simple interface for agents to perform OAuth authentication, using the [`OAuthParams`][fixieai.agents.oauthparams] class. Using this class, an agent function can use the [`OAuthHandler`][fixieai.agents.oauthhandler] class, passed to the function as the `oauth_handler` parameter, to obtain an access token for the user.
+Fixie provides a simple interface for agents to perform OAuth authentication, using the [`OAuthParams`][fixieai.agents.oauth.OAuthParams] class. Using this class, an agent function can use the [`OAuthHandler`][fixieai.agents.oauth.OAuthHandler] class, passed to the function as the `oauth_handler` parameter, to obtain an access token for the user.
 
 ### OAuth Example
 

--- a/docs/python-agent-api.md
+++ b/docs/python-agent-api.md
@@ -8,6 +8,10 @@
     options:
       show_source: true
 
+## ::: fixieai.agents.corpora
+    options:
+      show_source: true
+
 ## ::: fixieai.agents.oauth
     options:
       show_source: true

--- a/fixieai/agents/corpora.py
+++ b/fixieai/agents/corpora.py
@@ -12,15 +12,16 @@ class CorpusRequest(dataclasses_json.DataClassJsonMixin):
     """A request for some piece of the agent's corpus.
 
     In addition to returning documents, each response may expand the corpus
-    space in one or both of two dimensions:
-        Responses may include new partitions to be loaded. Partitions are
-            non-overlapping subsets of a corpus which may be loaded in parallel
-            by Fixie. A response's new partitions will be ignored if previously
-            included in another response.
-        When a response includes a page of documents, that page may indicate
-            that another page is available in the same partition. Pages are
-            always loaded serially in order. The partition is completed when
-            a response has a page with no next_page_token.
+    space in one or both of two dimensions: new partitions and next pages.
+
+    Partitions are non-overlapping subsets of a corpus which may be loaded in
+    parallel by Fixie. A response's new partitions will be ignored if
+    previously included in another response.
+
+    When a response includes a page of documents, that page may indicate that
+    another page is available in the same partition. Pages are always loaded
+    serially in order. The partition is completed when a response has a page
+    with no next_page_token.
 
     Agents will always receive a first request with the default (unnamed)
     partition and no page_token. Subsequent requests depend on prior responses
@@ -28,10 +29,13 @@ class CorpusRequest(dataclasses_json.DataClassJsonMixin):
 
     Examples:
         Simple handful of documents:
+
             When receiving the initial request, the agent responds with a page
             of documents. This could include a next_page_token for more
             documents in the single default partition if needed.
+
         Web crawl:
+
             Each URL corresponds to a partition and the agent never returns
             tokens. The initial response only includes partitions, one for each
             root URL to crawl. Each subsequent request includes the partition
@@ -41,7 +45,9 @@ class CorpusRequest(dataclasses_json.DataClassJsonMixin):
             response also contains those URLs as new partitions. The process
             repeats for all partitions until there are no known incomplete
             partitions or until crawl limits are reached.
+
         Database:
+
             Consider a database with a parent table keyed by parent_id and an
             interleaved child table keyed by (parent_id, child_id) whose rows
             correspond to corpus documents. This agent will use tokens that
@@ -66,7 +72,7 @@ class CorpusRequest(dataclasses_json.DataClassJsonMixin):
                 work and would be an effective way to limit parallelism if
                 desired.
 
-    Args:
+    Attributes:
         partition: The partition of the corpus that should be read. This will
             be empty for the initial request, indicating the default partition.
             For subsequent requests, it will either be the name of a partition


### PR DESCRIPTION
Also reformat docstrings for better generated documentation and fix some docs generation warnings.