### PR TITLE
Allow `fixie agent deploy` to deploy node.js agents

### DIFF
--- a/fixieai/__init__.py
+++ b/fixieai/__init__.py
@@ -18,6 +18,7 @@ from fixieai.agents import StandaloneAgent
 from fixieai.agents import UrlDocumentCorpus
 from fixieai.agents import UserStorage
 from fixieai.client import FixieClient
+from fixieai.client import FixieEnvironment
 from fixieai.client import get_agents
 from fixieai.client import get_client
 from fixieai.client import get_embeds
@@ -42,6 +43,7 @@ __all__ = [
     "UrlDocumentCorpus",
     "UserStorage",
     "FixieClient",
+    "FixieEnvironment",
     "get_agents",
     "get_client",
     "get_embeds",

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -598,7 +598,7 @@ def deploy(ctx, path, metadata_only, public, validate):
                         tarball,
                     )
                     tarball_file.seek(0)
-                    with _spinner(console, "Deploying..."):
+                    with _spinner(console, "Deploying Python..."):
                         ctx.obj.client.deploy_agent(
                             config.handle,
                             tarball_file,
@@ -608,7 +608,7 @@ def deploy(ctx, path, metadata_only, public, validate):
             tgz_name = package_json["name"] + "-" + package_json["version"] + ".tgz"
             subprocess.check_call(["npm", "pack"], cwd=agent_dir)
             tarball_file = open(tgz_name, "rb")
-            with _spinner(console, "Deploying..."):
+            with _spinner(console, "Deploying JS..."):
                 ctx.obj.client.deploy_agent(
                     config.handle,
                     tarball_file,

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -717,15 +717,16 @@ def _agent_py_code_package(
 def _agent_js_code_package(
     agent_dir: str, agent_id: str, console: rich_console.Console
 ):
+    agent_path = os.path.abspath(agent_dir)
     with tempfile.TemporaryDirectory() as tarball_dir:
-        print("tarball dir", tarball_dir)
-        package_json_path = os.path.join(agent_dir, "package.json")
+        print("agent dir", agent_path)
+        package_json_path = os.path.join(agent_path, "package.json")
         with open(package_json_path) as package_json_file:
             package_json = json.load(package_json_file)
         tarball_path = os.path.join(
             tarball_dir, package_json["name"] + "-" + package_json["version"] + ".tgz"
         )
-        subprocess.check_call(["npm", "pack", agent_dir], cwd=tarball_dir)
+        subprocess.check_call(["npm", "pack", agent_path], cwd=tarball_dir)
         print("tb path", tarball_path)
         tarball_file = open(tarball_path, "rb")
     yield tarball_file

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -811,8 +811,9 @@ def deploy(ctx, path, metadata_only, public, validate, make_current, metadata, r
                     config.handle,
                     make_current=make_current,
                     metadata=metadata_dict,
-                    python_gzip_tarfile=tarball_file,
+                    gzip_tarfile=tarball_file,
                     reindex_corpora=reindex,
+                    environment="NODEJS",
                 )
         else:
             with _agent_py_code_package(
@@ -822,8 +823,9 @@ def deploy(ctx, path, metadata_only, public, validate, make_current, metadata, r
                     config.handle,
                     make_current=make_current,
                     metadata=metadata_dict,
-                    python_gzip_tarfile=tarball_file,
+                    gzip_tarfile=tarball_file,
                     reindex_corpora=reindex,
+                    environment="PYTHON",
                 )
     else:
         # Create a new revision with the specified URL.

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -717,12 +717,17 @@ def _agent_py_code_package(
 def _agent_js_code_package(
     agent_dir: str, agent_id: str, console: rich_console.Console
 ):
-    package_json_path = os.path.join(agent_dir, "package.json")
-    with open(package_json_path) as package_json_file:
-        package_json = json.load(package_json_file)
-    tgz_name = package_json["name"] + "-" + package_json["version"] + ".tgz"
-    subprocess.check_call(["npm", "pack"], cwd=agent_dir)
-    tarball_file = open(tgz_name, "rb")
+    with tempfile.TemporaryDirectory as tarball_dir:
+        print("tarball dir", tarball_dir)
+        package_json_path = os.path.join(agent_dir, "package.json")
+        with open(package_json_path) as package_json_file:
+            package_json = json.load(package_json_file)
+        tarball_path = os.path.join(
+            tarball_dir, package_json["name"] + "-" + package_json["version"] + ".tgz"
+        )
+        subprocess.check_call(["npm", "pack", agent_dir], cwd=tarball_dir)
+        print("tb path", tarball_path)
+        tarball_file = open(tarball_path, "rb")
     yield tarball_file
 
 

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -714,12 +714,9 @@ def _agent_py_code_package(
 
 
 @contextlib.contextmanager
-def _agent_js_code_package(
-    agent_dir: str, agent_id: str, console: rich_console.Console
-):
+def _agent_js_code_package(agent_dir: str):
     agent_path = os.path.abspath(agent_dir)
     with tempfile.TemporaryDirectory() as tarball_dir:
-        print("agent dir", agent_path)
         package_json_path = os.path.join(agent_path, "package.json")
         with open(package_json_path) as package_json_file:
             package_json = json.load(package_json_file)
@@ -727,7 +724,6 @@ def _agent_js_code_package(
             tarball_dir, package_json["name"] + "-" + package_json["version"] + ".tgz"
         )
         subprocess.check_call(["npm", "pack", agent_path], cwd=tarball_dir)
-        print("tb path", tarball_path)
         tarball_file = open(tarball_path, "rb")
     yield tarball_file
 
@@ -810,9 +806,9 @@ def deploy(ctx, path, metadata_only, public, validate, make_current, metadata, r
     if config.deployment_url is None:
         # Deploy the code to Fixie.
         if is_js_agent:
-            with _agent_js_code_package(
-                agent_dir, agent_id, console
-            ) as tarball_file, _spinner(console, "Deploying JS..."):
+            with _agent_js_code_package(agent_dir) as tarball_file, _spinner(
+                console, "Deploying..."
+            ):
                 revision_id = client.create_agent_revision(
                     config.handle,
                     make_current=make_current,
@@ -824,7 +820,7 @@ def deploy(ctx, path, metadata_only, public, validate, make_current, metadata, r
         else:
             with _agent_py_code_package(
                 agent_dir, agent_id, console
-            ) as tarball_file, _spinner(console, "Deploying Python..."):
+            ) as tarball_file, _spinner(console, "Deploying..."):
                 revision_id = client.create_agent_revision(
                     config.handle,
                     make_current=make_current,

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -725,7 +725,7 @@ def _agent_js_code_package(agent_dir: str):
         )
         subprocess.check_call(["npm", "pack", agent_path], cwd=tarball_dir)
         tarball_file = open(tarball_path, "rb")
-    yield tarball_file
+        yield tarball_file
 
 
 @agent.command("deploy", help="Deploy the current agent.")
@@ -815,7 +815,7 @@ def deploy(ctx, path, metadata_only, public, validate, make_current, metadata, r
                     metadata=metadata_dict,
                     gzip_tarfile=tarball_file,
                     reindex_corpora=reindex,
-                    environment="NODEJS",
+                    environment=fixieai.client.FixieEnvironment.NODEJS,
                 )
         else:
             with _agent_py_code_package(
@@ -827,7 +827,7 @@ def deploy(ctx, path, metadata_only, public, validate, make_current, metadata, r
                     metadata=metadata_dict,
                     gzip_tarfile=tarball_file,
                     reindex_corpora=reindex,
-                    environment="PYTHON",
+                    environment=fixieai.client.FixieEnvironment.PYTHON,
                 )
     else:
         # Create a new revision with the specified URL.

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -717,7 +717,7 @@ def _agent_py_code_package(
 def _agent_js_code_package(
     agent_dir: str, agent_id: str, console: rich_console.Console
 ):
-    with tempfile.TemporaryDirectory as tarball_dir:
+    with tempfile.TemporaryDirectory() as tarball_dir:
         print("tarball dir", tarball_dir)
         package_json_path = os.path.join(agent_dir, "package.json")
         with open(package_json_path) as package_json_file:

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -780,8 +780,10 @@ def deploy(ctx, path, metadata_only, public, validate, make_current, metadata, r
         )
     if public:
         config.public = True
+
     client: fixieai.FixieClient = ctx.obj.client
     agent_id = f"{client.get_current_username()}/{config.handle}"
+    console.print(f"🦊 Deploying agent [green]{agent_id}[/]...")
 
     agent_dir = os.path.dirname(path) or "."
     package_json_path = os.path.join(agent_dir, "package.json")

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -718,7 +718,8 @@ def _agent_js_code_package(
     agent_dir: str, agent_id: str, console: rich_console.Console
 ):
     package_json_path = os.path.join(agent_dir, "package.json")
-    package_json = json.load(package_json_path)
+    with open(package_json_path) as package_json_file:
+        package_json = json.load(package_json_file)
     tgz_name = package_json["name"] + "-" + package_json["version"] + ".tgz"
     subprocess.check_call(["npm", "pack"], cwd=agent_dir)
     tarball_file = open(tgz_name, "rb")

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -811,7 +811,7 @@ def deploy(ctx, path, metadata_only, public, validate, make_current, metadata, r
                     config.handle,
                     make_current=make_current,
                     metadata=metadata_dict,
-                    javascript_gzip_tarfile=tarball_file,
+                    python_gzip_tarfile=tarball_file,
                     reindex_corpora=reindex,
                 )
         else:

--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -721,7 +721,7 @@ def _agent_js_code_package(agent_dir: str):
         with open(package_json_path) as package_json_file:
             package_json = json.load(package_json_file)
         tarball_path = os.path.join(
-            tarball_dir, package_json["name"] + "-" + package_json["version"] + ".tgz"
+            tarball_dir, f"{package_json['name']}-{package_json['version']}.tgz"
         )
         subprocess.check_call(["npm", "pack", agent_path], cwd=tarball_dir)
         tarball_file = open(tarball_path, "rb")

--- a/fixieai/client/__init__.py
+++ b/fixieai/client/__init__.py
@@ -1,4 +1,5 @@
 from fixieai.client.client import FixieClient
+from fixieai.client.client import FixieEnvironment
 from fixieai.client.client import get_agents
 from fixieai.client.client import get_client
 from fixieai.client.client import get_embeds
@@ -6,6 +7,7 @@ from fixieai.client.client import query
 
 __all__ = [
     "FixieClient",
+    "FixieEnvironment",
     "get_agents",
     "get_client",
     "get_embeds",

--- a/fixieai/client/client.py
+++ b/fixieai/client/client.py
@@ -221,7 +221,8 @@ class FixieClient:
         reindex_corpora: bool = False,
         metadata: Optional[Dict[str, str]] = None,
         external_url: Optional[str] = None,
-        python_gzip_tarfile: Optional[BinaryIO] = None,
+        gzip_tarfile: Optional[BinaryIO] = None,
+        environment: str = "PYTHON",
     ) -> str:
         """Creates a new Agent revision.
 
@@ -231,7 +232,7 @@ class FixieClient:
             reindex_corpora: Whether to reindex all corpora for the new revision.
             metadata: Optional client-provided metadata to associate with the revision.
             external_url: The URL at which the revision is hosted, if hosted externally.
-            python_gzip_tarfile: A file-like of a gzip-compressed tarfile containing the files to deploy.
+            gzip_tarfile: A file-like of a gzip-compressed tarfile containing the files to deploy.
 
         Exactly one of `external_url` and `python_gzip_tarfile` must be provided.
         """
@@ -277,10 +278,10 @@ class FixieClient:
                     if external_url
                     else None,
                     "managedDeployment": {
-                        "environment": "PYTHON",
-                        "codePackage": python_gzip_tarfile,
+                        "environment": environment,
+                        "codePackage": gzip_tarfile,
                     }
-                    if python_gzip_tarfile
+                    if gzip_tarfile
                     else None,
                 },
                 upload_files=True,

--- a/fixieai/client/client.py
+++ b/fixieai/client/client.py
@@ -233,8 +233,9 @@ class FixieClient:
             metadata: Optional client-provided metadata to associate with the revision.
             external_url: The URL at which the revision is hosted, if hosted externally.
             gzip_tarfile: A file-like of a gzip-compressed tarfile containing the files to deploy.
+            environment: The environment in which the revision should be run. Must be one of "PYTHON" or "NODEJS".
 
-        Exactly one of `external_url` and `python_gzip_tarfile` must be provided.
+        Exactly one of `external_url` and `gzip_tarfile` must be provided.
         """
 
         mutation = gql(

--- a/fixieai/client/client.py
+++ b/fixieai/client/client.py
@@ -367,7 +367,9 @@ class FixieClient:
             mutation, variable_values={"handle": handle, "revisionId": revision_id}
         )
 
-    def deploy_agent(self, handle: str, gzip_tarfile: BinaryIO, environment: str):
+    def deploy_agent(
+        self, handle: str, gzip_tarfile: BinaryIO, environment: FixieEnvironment
+    ):
         """Deploys an agent implementation.
 
         Args:

--- a/fixieai/client/client.py
+++ b/fixieai/client/client.py
@@ -261,7 +261,7 @@ class FixieClient:
         )
 
         with utils.patched_gql_file_uploader(
-            python_gzip_tarfile, "upload.tar.gz", "application/gzip"
+            gzip_tarfile, "upload.tar.gz", "application/gzip"
         ):
             result = self._gqlclient.execute(
                 mutation,
@@ -359,11 +359,7 @@ class FixieClient:
             mutation, variable_values={"handle": handle, "revisionId": revision_id}
         )
 
-    def deploy_agent(
-        self,
-        handle: str,
-        gzip_tarfile: BinaryIO,
-    ):
+    def deploy_agent(self, handle: str, gzip_tarfile: BinaryIO, environment: str):
         """Deploys an agent implementation.
 
         Args:
@@ -373,5 +369,6 @@ class FixieClient:
         return self.create_agent_revision(
             handle,
             make_current=True,
-            python_gzip_tarfile=gzip_tarfile,
+            gzip_tarfile=gzip_tarfile,
+            environment=environment,
         )

--- a/fixieai/client/client.py
+++ b/fixieai/client/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import enum
 import logging
 from typing import Any, BinaryIO, Dict, List, Optional
 
@@ -14,6 +15,12 @@ from fixieai import constants
 from fixieai.client import utils
 from fixieai.client.agent import Agent
 from fixieai.client.session import Session
+
+
+class FixieEnvironment(enum.Enum):
+    PYTHON = "PYTHON"
+    NODEJS = "NODEJS"
+
 
 _CLIENT: Optional["FixieClient"] = None
 _SESSION: Optional[Session] = None
@@ -222,7 +229,7 @@ class FixieClient:
         metadata: Optional[Dict[str, str]] = None,
         external_url: Optional[str] = None,
         gzip_tarfile: Optional[BinaryIO] = None,
-        environment: str = "PYTHON",
+        environment: FixieEnvironment = FixieEnvironment.PYTHON,
     ) -> str:
         """Creates a new Agent revision.
 
@@ -233,7 +240,7 @@ class FixieClient:
             metadata: Optional client-provided metadata to associate with the revision.
             external_url: The URL at which the revision is hosted, if hosted externally.
             gzip_tarfile: A file-like of a gzip-compressed tarfile containing the files to deploy.
-            environment: The environment in which the revision should be run. Must be one of "PYTHON" or "NODEJS".
+            environment: The environment in which the revision should be run.
 
         Exactly one of `external_url` and `gzip_tarfile` must be provided.
         """


### PR DESCRIPTION
The environment decision is triggered by the presence or absence of `package.json` in the root agent dir.