### PR TITLE
Add token streaming support to CLI

### DIFF
--- a/fixieai/cli/agent/commands.py
+++ b/fixieai/cli/agent/commands.py
@@ -270,6 +270,13 @@ def delete_agent(ctx, handle: str):
     click.echo(f"Deleted agent {agent.agent_id}")
 
 
+def _get_agent_type(agent_dir) -> fixieai.client.FixieEnvironment:
+    if os.path.exists(os.path.join(agent_dir, "package.json")):
+        return fixieai.client.FixieEnvironment.NODEJS
+    else:
+        return fixieai.client.FixieEnvironment.PYTHON
+
+
 def _validate_agent_path(ctx, param, value):
     normalized = agent_config.normalize_path(value)
     if not os.path.exists(normalized):
@@ -427,7 +434,8 @@ def _temporary_revision_replacer(
 def _server_process(
     console: rich_console.Console,
     on_exit_event: threading.Event,
-    python_exe: str,
+    agent_type: fixieai.client.FixieEnvironment,
+    agent_exe: str,
     host: str,
     port: int,
     agent_env: Dict[str, str],
@@ -436,9 +444,9 @@ def _server_process(
 ):
     """Yields a Popen object with a running and ready server process."""
 
-    with subprocess.Popen(
-        [
-            os.path.abspath(python_exe),
+    if agent_type == fixieai.client.FixieEnvironment.PYTHON:
+        args = [
+            os.path.abspath(agent_exe),
             "-m",
             "uvicorn",
             "fixieai.cli.agent.loader:uvicorn_app_factory",
@@ -447,7 +455,17 @@ def _server_process(
             "--port",
             str(port),
             "--factory",
-        ],
+        ]
+    elif agent_type == fixieai.client.FixieEnvironment.NODEJS:
+        args = [
+            agent_exe,
+            "ts-node",
+            os.path.join(agent_dir, "dist/serve-bin.js"),
+            "--port",
+            str(port),
+        ]
+    with subprocess.Popen(
+        args,
         env=agent_env,
         cwd=agent_dir or None,
     ) as popen:
@@ -531,12 +549,21 @@ def serve(ctx, path, host, port, use_tunnel, reload, use_venv):
 
     with contextlib.ExitStack() as stack:
         agent_dir = os.path.dirname(path) or "."
+        agent_type = _get_agent_type(agent_dir)
 
         # Configure the virtual enviroment
-        if use_venv:
-            python_exe, agent_env = _configure_venv(console, agent_dir)
-        else:
-            python_exe, agent_env = sys.executable, os.environ.copy()
+        if agent_type == fixieai.client.FixieEnvironment.PYTHON:
+            if use_venv:
+                agent_exe, agent_env = _configure_venv(console, agent_dir)
+            else:
+                agent_exe, agent_env = sys.executable, os.environ.copy()
+        elif agent_type == fixieai.client.FixieEnvironment.NODEJS:
+            if use_venv:
+                # TODO: Implement virtual environment for node
+                pass
+            else:
+                agent_exe = "npx"
+                agent_env = os.environ.copy()
         agent_env[FIXIE_ALLOWED_AGENT_ID] = agent_id
 
         if use_tunnel:
@@ -585,7 +612,8 @@ def serve(ctx, path, host, port, use_tunnel, reload, use_venv):
             with _server_process(
                 console,
                 requires_action,
-                python_exe,
+                agent_type,
+                agent_exe,
                 host,
                 port,
                 agent_env,
@@ -679,6 +707,21 @@ def _add_text_file_to_tarfile(path: str, text: str, tarball: tarfile.TarFile):
     tarinfo = tarfile.TarInfo(path)
     tarinfo.size = len(file_bytes)
     tarball.addfile(tarinfo, io.BytesIO(file_bytes))
+
+
+@contextlib.contextmanager
+def _agent_code_package(
+    agent_type: fixieai.client.FixieEnvironment,
+    agent_dir: str,
+    agent_id: str,
+    console: rich_console.Console,
+):
+    if agent_type == fixieai.client.FixieEnvironment.PYTHON:
+        return _agent_py_code_package(agent_dir, agent_id, console)
+    elif agent_type == fixieai.client.FixieEnvironment.NODEJS:
+        return _agent_js_code_package(agent_dir)
+    else:
+        raise ValueError(f"Unknown agent type {agent_type}")
 
 
 @contextlib.contextmanager
@@ -789,9 +832,8 @@ def deploy(ctx, path, metadata_only, public, validate, make_current, metadata, r
     console.print(f"🦊 Deploying agent [green]{agent_id}[/]...")
 
     agent_dir = os.path.dirname(path) or "."
-    package_json_path = os.path.join(agent_dir, "package.json")
-    is_js_agent = os.path.exists(package_json_path)
-    if validate and not is_js_agent:
+    agent_type = _get_agent_type(agent_dir)
+    if validate and agent_type == fixieai.client.FixieEnvironment.PYTHON:
         # Validate that the agent loads in a virtual environment before deploying.
         python_exe, agent_env = _configure_venv(console, agent_dir)
         agent_env[FIXIE_ALLOWED_AGENT_ID] = agent_id
@@ -805,30 +847,17 @@ def deploy(ctx, path, metadata_only, public, validate, make_current, metadata, r
 
     if config.deployment_url is None:
         # Deploy the code to Fixie.
-        if is_js_agent:
-            with _agent_js_code_package(agent_dir) as tarball_file, _spinner(
-                console, "Deploying..."
-            ):
-                revision_id = client.create_agent_revision(
-                    config.handle,
-                    make_current=make_current,
-                    metadata=metadata_dict,
-                    gzip_tarfile=tarball_file,
-                    reindex_corpora=reindex,
-                    environment=fixieai.client.FixieEnvironment.NODEJS,
-                )
-        else:
-            with _agent_py_code_package(
-                agent_dir, agent_id, console
-            ) as tarball_file, _spinner(console, "Deploying..."):
-                revision_id = client.create_agent_revision(
-                    config.handle,
-                    make_current=make_current,
-                    metadata=metadata_dict,
-                    gzip_tarfile=tarball_file,
-                    reindex_corpora=reindex,
-                    environment=fixieai.client.FixieEnvironment.PYTHON,
-                )
+        with _agent_code_package(
+            agent_type, agent_dir, agent_id, console
+        ) as tarball_file, _spinner(console, "Deploying..."):
+            revision_id = client.create_agent_revision(
+                config.handle,
+                make_current=make_current,
+                metadata=metadata_dict,
+                gzip_tarfile=tarball_file,
+                reindex_corpora=reindex,
+                environment=agent_type,
+            )
     else:
         # Create a new revision with the specified URL.
         with _spinner(console, "Deploying..."):

--- a/fixieai/cli/session/console.py
+++ b/fixieai/cli/session/console.py
@@ -64,17 +64,20 @@ class Console:
 
     def _query(self, in_text: str) -> None:
         try:
+            self._response_index += 1
+            print(f"{self._response_index}❯ ", end="")
             pos = 0
+            sys.stdout.flush()
             for message in self._session.streaming_query(in_text):
                 text = message["text"][pos:]
                 print(text, end="")
                 sys.stdout.flush()
                 pos += len(text)
-                # self._show_message(message)
+            print("")
+            self._show_embeds(message["text"])
         except requests.exceptions.HTTPError as e:
             textconsole.print(f"🚨 {e}")
             return
-        print("")
 
     def _show_message(self, message: Dict[str, Any], show_user_message: bool = False):
         """Shows a message dict from FixieClient.
@@ -88,10 +91,10 @@ class Console:
         )
         message_text = message["text"]
 
-        if message.get("type") == "query" and sender_handle == "user":
+        if message["type"] == "query" and sender_handle == "user":
             if show_user_message:
                 textconsole.print(Markdown(PROMPT + message_text))
-        elif message.get("type") and message.get("type") != "response":
+        elif message["type"] != "response":
             textconsole.print(
                 Markdown(f"   @{sender_handle}: " + message_text, style="dim")
             )

--- a/fixieai/cli/session/console.py
+++ b/fixieai/cli/session/console.py
@@ -63,7 +63,6 @@ class Console:
             self._query(in_text)
 
     def _query(self, in_text: str) -> None:
-        # with textconsole.status("Working...", spinner="bouncingBall"):
         try:
             pos = 0
             for message in self._session.streaming_query(in_text):

--- a/fixieai/cli/session/console.py
+++ b/fixieai/cli/session/console.py
@@ -1,6 +1,7 @@
 import io
 import os.path
 import re
+import sys
 from typing import Any, Dict, List, Optional
 
 import prompt_toolkit
@@ -44,7 +45,7 @@ class Console:
         textconsole.print(f"Connected to: {self._session.session_url}")
 
         # Show what's already in the session thus far.
-        for message in self._session.get_messages_since_last_time():
+        for message in self._session.get_messages():
             self._show_message(message, show_user_message=True)
 
         history = prompt_toolkit.history.FileHistory(self._history_file)
@@ -62,13 +63,19 @@ class Console:
             self._query(in_text)
 
     def _query(self, in_text: str) -> None:
-        with textconsole.status("Working...", spinner="bouncingBall"):
-            try:
-                for message in self._session.run(in_text):
-                    self._show_message(message)
-            except requests.exceptions.HTTPError as e:
-                textconsole.print(f"🚨 {e}")
-                return
+        # with textconsole.status("Working...", spinner="bouncingBall"):
+        try:
+            pos = 0
+            for message in self._session.streaming_query(in_text):
+                text = message["text"][pos:]
+                print(text, end="")
+                sys.stdout.flush()
+                pos += len(text)
+                # self._show_message(message)
+        except requests.exceptions.HTTPError as e:
+            textconsole.print(f"🚨 {e}")
+            return
+        print("")
 
     def _show_message(self, message: Dict[str, Any], show_user_message: bool = False):
         """Shows a message dict from FixieClient.
@@ -78,14 +85,14 @@ class Console:
         to a session.
         """
         sender_handle = (
-            message["sentBy"]["handle"] if message["sentBy"] else "<unknown>"
+            message["sentBy"]["handle"] if message.get("sentBy") else "<unknown>"
         )
         message_text = message["text"]
 
-        if message["type"] == "query" and sender_handle == "user":
+        if message.get("type") == "query" and sender_handle == "user":
             if show_user_message:
                 textconsole.print(Markdown(PROMPT + message_text))
-        elif message["type"] != "response":
+        elif message.get("type") and message.get("type") != "response":
             textconsole.print(
                 Markdown(f"   @{sender_handle}: " + message_text, style="dim")
             )

--- a/fixieai/client/client.py
+++ b/fixieai/client/client.py
@@ -379,13 +379,29 @@ class FixieClient:
         )
 
     def post(self, url: str, data: Optional[Dict[str, Any]] = None) -> Any:
+        """Performs a POST request with the appropriate auth token.
+        The response will be parsed as JSON and returned.
+
+        Args:
+            url: The URL to POST to, which should start with https://api.fixie.ai/api
+            data: The data to send in the request body (optional)
+        """
+        assert url.startswith("https://api.fixie.ai/api")
         response = self._rest_client.post(url, headers=self._request_headers, json=data)
         response.raise_for_status()
         return response.json()
 
     def streaming_post(
-        self, url: str, data: Dict[str, Any]
+        self, url: str, data: Optional[Dict[str, Any]] = None
     ) -> Generator[Any, None, None]:
+        """Performs a POST request with the appropriate auth token, and handles a streaming response.
+        The response will be yielded as a generator of JSON objects, one per line.
+
+        Args:
+            url: The URL to POST to, which should start with https://api.fixie.ai/api
+            data: The data to send in the request body (optional)
+        """
+        assert url.startswith("https://api.fixie.ai/api")
         response = self._rest_client.post(
             url, headers=self._request_headers, json=data, stream=True
         )

--- a/fixieai/client/client.py
+++ b/fixieai/client/client.py
@@ -379,14 +379,14 @@ class FixieClient:
         )
 
     def post(self, url: str, data: Dict[str, Any]) -> Dict[str, Any]:
-        response = requests.post(url, headers=self._request_headers, json=data)
+        response = self._rest_client.post(url, headers=self._request_headers, json=data)
         response.raise_for_status()
         return response.json()
 
     def streaming_post(
         self, url: str, data: Dict[str, Any]
     ) -> Generator[Dict[str, Any], None, None]:
-        response = requests.post(
+        response = self._rest_client.post(
             url, headers=self._request_headers, json=data, stream=True
         )
         response.raise_for_status()

--- a/fixieai/client/client.py
+++ b/fixieai/client/client.py
@@ -378,14 +378,14 @@ class FixieClient:
             environment=environment,
         )
 
-    def post(self, url: str, data: Dict[str, Any]) -> Dict[str, Any]:
+    def post(self, url: str, data: Optional[Dict[str, Any]] = None) -> Any:
         response = self._rest_client.post(url, headers=self._request_headers, json=data)
         response.raise_for_status()
         return response.json()
 
     def streaming_post(
         self, url: str, data: Dict[str, Any]
-    ) -> Generator[Dict[str, Any], None, None]:
+    ) -> Generator[Any, None, None]:
         response = self._rest_client.post(
             url, headers=self._request_headers, json=data, stream=True
         )

--- a/fixieai/client/session.py
+++ b/fixieai/client/session.py
@@ -192,7 +192,7 @@ class Session:
         """Run a single query against the Fixie API and return the response."""
         final = ""
         for message in self.streaming_query(text):
-            final = message
+            final = message["text"]
         return final
 
     def streaming_query(self, text: str) -> Generator[Dict[str, Any], None, None]:

--- a/fixieai/client/session.py
+++ b/fixieai/client/session.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import datetime
-import threading
-import time
+from fixieai import constants
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional
 
 from gql import gql
@@ -35,6 +33,7 @@ class Session:
         self._client = client
         self._gqlclient = self._client.gqlclient
         self._session_id = session_id
+        self._frontend_agent_id = frontend_agent_id
         if session_id:
             # Test that the session exists.
             _ = self.get_metadata()
@@ -43,8 +42,6 @@ class Session:
             ), "Cannot specify frontend_agent_id when using an existing session"
         else:
             self._session_id = self._create_session(frontend_agent_id)
-        self._frontend_agent_id: Optional[str] = None
-        self._last_message_timestamp: Optional[datetime.datetime] = None
 
     @property
     def session_id(self) -> Optional[str]:
@@ -60,10 +57,6 @@ class Session:
     def frontend_agent_id(self) -> Optional[str]:
         """Return the frontend agent ID used by this Fixie client."""
         return self._frontend_agent_id
-
-    def clone(self) -> "Session":
-        """Return a new Session instance with the same configuration."""
-        return Session(self._client.clone(), session_id=self._session_id)
 
     def _create_session(self, frontend_agent_id: Optional[str] = None) -> str:
         """Create a new session."""
@@ -89,7 +82,6 @@ class Session:
             raise ValueError(f"Failed to create Session")
         assert isinstance(result["createSession"], dict)
         assert isinstance(result["createSession"]["session"], dict)
-        self._frontend_agent_id = result["createSession"]["session"]["frontendAgentId"]
         assert isinstance(result["createSession"]["session"]["handle"], str)
         return result["createSession"]["session"]["handle"]
 
@@ -195,57 +187,20 @@ class Session:
         )
         return result["sessionByHandle"]["messages"]
 
-    def add_message(self, text: str) -> str:
-        """Add a message to this Session. Returns the added message text."""
-        query = gql(
-            """
-            mutation Post($handle: String!, $text: String!) {
-                sendSessionMessage(messageData: {session: $handle, text: $text}) {
-                    message {
-                        text
-                    }
-                }
-            }
-            """
-        )
-        result = self._gqlclient.execute(
-            query, variable_values={"handle": self._session_id, "text": text}
-        )
-        assert isinstance(result["sendSessionMessage"]["message"]["text"], str)
-        return result["sendSessionMessage"]["message"]["text"]
-
-    def query(self, text: str) -> str:
+    def query(self, text: str):
         """Run a single query against the Fixie API and return the response."""
-        self.add_message(text)
-        # The reply to the query comes in as the most recent 'response' message in the
-        # session.
-        response = self.get_messages()[-1]
-        assert isinstance(response["text"], str)
-        return response["text"]
+        final = None
+        for message in self.streaming_query(text):
+            final = message
+        return final
 
-    def run(self, text: str) -> Generator[Dict[str, Any], None, None]:
-        """Run a query against the Fixie API, returning a generator that yields
-        messages."""
-
-        # Run the query in the background, and continue polling for replies.
-        background_client = self.clone()
-        threading.Thread(target=background_client.add_message, args=(text,)).start()
-
-        response_received = False
-        while not response_received:
-            time.sleep(1)
-            messages = self.get_messages_since_last_time()
-            for message in messages:
-                response_received = message["type"] == "response"
-                yield message
-
-    def get_messages_since_last_time(self) -> List[Dict[str, Any]]:
-        """Return all messages since the given timestamp."""
-        timestamp = self._last_message_timestamp
-        messages_since_last_time = []
-        for message in self.get_messages():
-            message_timestamp = datetime.datetime.fromisoformat(message["timestamp"])
-            if timestamp is None or message_timestamp > timestamp:
-                messages_since_last_time.append(message)
-                self._last_message_timestamp = message_timestamp
-        return messages_since_last_time
+    def streaming_query(self, text: str) -> Generator[Dict[str, Any], None, None]:
+        """Run a single query against the Fixie API and return a stream."""
+        data = {
+            "session": self._session_id,
+            "message": {"text": text},
+            "stream": True,
+        }
+        url = f"{constants.FIXIE_AGENT_URL}/{self._frontend_agent_id}"
+        gen = self._client.streaming_post(url, data)
+        return (response["message"] for response in gen)

--- a/fixieai/client/session.py
+++ b/fixieai/client/session.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from fixieai import constants
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional
 
 from gql import gql
+
+from fixieai import constants
 
 if TYPE_CHECKING:
     import fixieai.client as fixie_client
@@ -187,9 +188,9 @@ class Session:
         )
         return result["sessionByHandle"]["messages"]
 
-    def query(self, text: str):
+    def query(self, text: str) -> str:
         """Run a single query against the Fixie API and return the response."""
-        final = None
+        final = ""
         for message in self.streaming_query(text):
             final = message
         return final
@@ -202,5 +203,8 @@ class Session:
             "stream": True,
         }
         url = f"{constants.FIXIE_AGENT_URL}/{self._frontend_agent_id}"
-        gen = self._client.streaming_post(url, data)
-        return (response["message"] for response in gen)
+        for response in self._client.streaming_post(url, data):
+            yield {
+                "text": response["message"]["text"],
+                "type": response["type"],
+            }

--- a/fixieai/constants.py
+++ b/fixieai/constants.py
@@ -13,6 +13,8 @@ FIXIE_CONFIG_PATH = os.getenv(
 
 # Fixie's GraphQL URL.
 FIXIE_GRAPHQL_URL = f"{FIXIE_API_URL}/graphql"
+# Fixie's Agent service URL.
+FIXIE_AGENT_URL = f"{FIXIE_API_URL}/api/agents"
 # Fixie's UserStorage service URL.
 FIXIE_USER_STORAGE_URL = f"{FIXIE_API_URL}/api/userstorage"
 # Fixie's refresh endpoint. It will be pinged when your agent comes alive.
@@ -29,7 +31,7 @@ FIXIE_OPENAI_PROXY_URL = f"{FIXIE_API_URL}/api/openai-proxy/v1"
 # Valid audiences for Fixie's query JWTs.
 FIXIE_AGENT_API_AUDIENCES = ["https://app.fixie.ai/api", "https://app.dev.fixie.ai/api"]
 # Fixie Agents' URL
-FIXIE_AGENT_URL = f"{FIXIE_API_URL}/agents"
+FIXIE_WEB_AGENT_URL = f"{FIXIE_API_URL}/agents"
 
 
 def fixie_api_key() -> str:


### PR DESCRIPTION
This switches the client over to use the REST /api/agents API rather than the graphql API, and accordingly allows us to remove some of the oddness of the old usage, including the need for a separate thread and polling of the get_messages API.