### PR TITLE
Ignore empty lines from /api/message

### DIFF
--- a/fixieai/cli/session/console.py
+++ b/fixieai/cli/session/console.py
@@ -9,7 +9,7 @@ import prompt_toolkit.history
 import requests
 from PIL import Image
 from rich import console as rich_console
-from rich.markdown import Markdown
+from rich import markdown
 
 from fixieai import FixieClient
 from fixieai.client.client import Session
@@ -70,7 +70,7 @@ class Console:
             sys.stdout.flush()
             for message in self._session.streaming_query(in_text):
                 text = message["text"][pos:]
-                print(text, end="")
+                textconsole.print(text, end="")
                 sys.stdout.flush()
                 pos += len(text)
             print("")
@@ -93,14 +93,16 @@ class Console:
 
         if message["type"] == "query" and sender_handle == "user":
             if show_user_message:
-                textconsole.print(Markdown(PROMPT + message_text))
+                textconsole.print(markdown.Markdown(PROMPT + message_text))
         elif message["type"] != "response":
             textconsole.print(
-                Markdown(f"   @{sender_handle}: " + message_text, style="dim")
+                markdown.Markdown(f"   @{sender_handle}: " + message_text, style="dim")
             )
         else:
             self._response_index += 1
-            textconsole.print(Markdown(f"{self._response_index}❯ " + message_text))
+            textconsole.print(
+                markdown.Markdown(f"{self._response_index}❯ " + message_text)
+            )
             self._show_embeds(message["text"])
 
     def _show_embeds(self, message: str):

--- a/fixieai/client/client.py
+++ b/fixieai/client/client.py
@@ -406,4 +406,4 @@ class FixieClient:
             url, headers=self._request_headers, json=data, stream=True
         )
         response.raise_for_status()
-        return (json.loads(line) for line in response.iter_lines())
+        return (json.loads(line) for line in response.iter_lines() if line)


### PR DESCRIPTION
For some reason we sometimes get spurious newlines from the server (possibly keepalives?) which causes JSON parsing to explode. 
Also use rich.console for streaming output. No Markdown yet because the Markdown parser isn't set up to go backwards and emit console codes when it detects, e.g., a heading, but I bet we could figure something out in the future.